### PR TITLE
Phase B の file workflow を skill に反映し、`build` スクリプトと smoke test を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ At the conversation boundary, the MVP passes state around as
 `mikuproject_workbook_json`.
 It does not try to replace the `mikuproject` browser UI.
 
+The repository also now documents a Phase B primary file workflow for
+`MS Project XML`, structural workbook `XLSX`, and `mikuproject_workbook_json`.
+
 Developer-oriented documents are available under [`docs/`](./docs/):
 
 - [`docs/agent-skill-design.md`](./docs/agent-skill-design.md)
@@ -61,6 +64,9 @@ Developer-oriented documents are available under [`docs/`](./docs/):
 
 会話境界では、MVP は state を `mikuproject_workbook_json` として持ち回ります。
 `mikuproject` のブラウザ UI を置き換えることは目指しません。
+
+あわせて、このリポジトリでは `MS Project XML`、構造忠実 workbook `XLSX`、
+`mikuproject_workbook_json` を扱う Phase B の primary file workflow も整理しています。
 
 開発者向け文書は [`docs/`](./docs/) にあります。
 

--- a/TODO.md
+++ b/TODO.md
@@ -115,18 +115,18 @@
 
 ### Phase B: Primary File Import/Export Workflow
 
-- [ ] `MS Project XML` の import 支援
-- [ ] `MS Project XML` の export 支援
-- [ ] `XLSX` の import 支援
-- [ ] `XLSX` の export 支援
-- [ ] `mikuproject_workbook_json` の import 支援
-- [ ] `mikuproject_workbook_json` の export 支援
+- [x] `MS Project XML` の import 支援
+- [x] `MS Project XML` の export 支援
+- [x] `XLSX` の import 支援
+- [x] `XLSX` の export 支援
+- [x] `mikuproject_workbook_json` の import 支援
+- [x] `mikuproject_workbook_json` の export 支援
 
 対象:
 
-- [ ] `MS Project XML`
-- [ ] `XLSX`
-- [ ] `mikuproject_workbook_json`
+- [x] `MS Project XML`
+- [x] `XLSX`
+- [x] `mikuproject_workbook_json`
 
 対象外:
 
@@ -143,6 +143,8 @@
 - [x] `docs/phase-b-msproject-xml-workflow.md` に `MS Project XML` 詳細仕様を作成する
 - [x] `docs/phase-b-workbook-json-workflow.md` に `mikuproject_workbook_json` 詳細仕様を作成する
 - [x] `docs/phase-b-xlsx-workflow.md` に `XLSX` 詳細仕様を作成する
+- [x] `skills/mikuproject/SKILL.md` に Phase B の操作を反映する
+- [x] `skills/mikuproject/references/` に `xml/xlsx/workbook` の短い利用例を追加する
 
 ### Phase C: Report / Presentation Outputs
 

--- a/docs/agent-skill-design.md
+++ b/docs/agent-skill-design.md
@@ -184,7 +184,7 @@ Skill は次のように振る舞う。
 
 ### soft error
 
-- upstream validator が warning を返した
+- upstream の validation check が warning を返した
 - Patch の一部 operation が無視された
 - workbook JSON の未知列や未知 sheet が無視された
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
+    "build": "npm test",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/skills/mikuproject/SKILL.md
+++ b/skills/mikuproject/SKILL.md
@@ -1,21 +1,34 @@
 ---
 name: mikuproject
-description: Work with mikuproject AI JSON workflows for WBS planning and iterative editing. Use when Codex needs to provide the mikuproject AI JSON spec, accept `project_draft_view`, apply `Patch JSON`, or hand off `mikuproject_workbook_json` for continued AI collaboration.
+description: Work with mikuproject AI JSON workflows and primary file import/export workflows. Use when Codex needs to provide the mikuproject AI JSON spec, accept `project_draft_view`, apply `Patch JSON`, hand off `mikuproject_workbook_json`, or move between the current state and `MS Project XML` or structural workbook `XLSX`.
 ---
 
 # Mikuproject
 
-Use this skill to drive the MVP workflow for `mikuproject` Agent Skills.
-Keep the focus on structured JSON exchange, not on replacing the browser UI.
+Use this skill to drive the current workflow for `mikuproject` Agent Skills.
+Keep the focus on structured exchange and primary file workflows, not on replacing the browser UI.
 
 ## Core Workflow
 
-Treat the skill as one workflow with four operations:
+Treat the skill as one workflow with two layers of operations.
+
+Phase A:
 
 - `spec`: provide `mikuproject-ai-json-spec`
 - `draft`: accept AI-produced `project_draft_view`
 - `patch`: accept AI-produced `Patch JSON`
 - `workbook`: return current `mikuproject_workbook_json`
+
+Phase B:
+
+- `xml-import`: accept `MS Project XML` and return `mikuproject_workbook_json`
+- `xml-export`: return current `MS Project XML`
+- `xlsx-import`: accept structural workbook `XLSX` and return `mikuproject_workbook_json`
+- `xlsx-merge-import`: apply structural workbook `XLSX` edits onto an existing state
+- `xlsx-export`: return current structural workbook `XLSX`
+- `workbook-import`: accept `mikuproject_workbook_json` as a replace import
+- `workbook-merge-import`: apply `mikuproject_workbook_json` onto an existing state
+- `workbook-export`: return current `mikuproject_workbook_json` as a file-oriented export
 
 At the conversation boundary, prefer `mikuproject_workbook_json` as the state exchange format.
 When processing input, convert through upstream APIs as needed.
@@ -36,8 +49,17 @@ Use these functions first:
 - `parseAiJsonText()`
 - `importAiJsonDocument()`
 - `importAiJsonText()`
+- `importExternal()`
+- `msProject.importFromXml()`
+- `msProject.exportToXml()`
 - `workbookJson.exportDocument()`
 - `workbookJson.importAsProjectModel()`
+- `workbookJson.importIntoProjectModel()`
+- `xlsx.decodeWorkbook()`
+- `xlsx.encodeWorkbook()`
+- `xlsx.exportWorkbook()`
+- `xlsx.importAsProjectModel()`
+- `xlsx.importIntoProjectModel()`
 - `patchJson.applyToProjectModel()`
 
 If you need the exact upstream file map or supporting design notes, read [references/upstream-map.md](references/upstream-map.md).
@@ -142,9 +164,11 @@ Treat these as hard errors:
 
 Treat these as soft errors:
 
-- upstream validators return warnings
+- upstream validation checks return warnings
 - some patch operations are ignored
 - workbook JSON contains unknown sheets or columns
+- unsupported workbook `XLSX` edits are ignored
+- merge imports apply only partial changes
 
 On soft errors, continue and report the warnings clearly.
 
@@ -156,6 +180,7 @@ Do not overreach beyond the MVP.
 - Do not claim business validity of the WBS itself
 - Do not add MCP-specific behavior unless the user asks for that expansion
 - Do not introduce extra skill splits unless the current single-skill design becomes limiting
+- Do not confuse structural workbook `XLSX` with `WBS XLSX`
 
 ## References
 
@@ -166,3 +191,7 @@ Read these only when needed:
 - [references/draft-import.md](references/draft-import.md) for `project_draft_view` acceptance and conversion rules
 - [references/patch-import.md](references/patch-import.md) for `Patch JSON` acceptance and apply rules
 - [references/workbook-handoff.md](references/workbook-handoff.md) for `mikuproject_workbook_json` handoff rules and prompt examples
+- [references/xml-import-export.md](references/xml-import-export.md) for `MS Project XML` import/export rules
+- [references/xlsx-import-export.md](references/xlsx-import-export.md) for structural workbook `XLSX` import/export rules
+- [references/workbook-import-export.md](references/workbook-import-export.md) for file-style workbook JSON import/export rules
+- [references/phase-b-examples.md](references/phase-b-examples.md) for short `xml/xlsx/workbook` import/export examples

--- a/skills/mikuproject/references/phase-b-examples.md
+++ b/skills/mikuproject/references/phase-b-examples.md
@@ -1,0 +1,62 @@
+# Phase B Examples
+
+Use these short examples when the user needs concrete prompts for the primary file workflow.
+
+## `xml-import`
+
+Input example:
+
+- "Import this `MS Project XML` and return the current state as `mikuproject_workbook_json`."
+
+Output shape:
+
+- one short line saying the XML import succeeded
+- warnings, if any
+- the resulting `mikuproject_workbook_json`
+
+## `xml-export`
+
+Input example:
+
+- "Export the current state as `MS Project XML`."
+
+Output shape:
+
+- one short line saying this is the current XML export
+- the generated XML text
+
+## `xlsx-import`
+
+Input example:
+
+- "Import this structural workbook `.xlsx` and return the current state as `mikuproject_workbook_json`."
+
+Output shape:
+
+- one short line saying the workbook `XLSX` import succeeded
+- warnings, if any
+- the resulting `mikuproject_workbook_json`
+
+## `xlsx-export`
+
+Input example:
+
+- "Export the current state as structural workbook `.xlsx`."
+
+Output shape:
+
+- one short line saying this is the current workbook `XLSX`
+- workbook sheet summary, when useful
+- the generated `.xlsx` bytes or file artifact
+
+## `workbook-import`
+
+Input example:
+
+- "Import this `mikuproject_workbook_json` as the new current state."
+
+Output shape:
+
+- one short line saying the workbook JSON import succeeded
+- warnings, if any
+- the resulting `mikuproject_workbook_json`

--- a/skills/mikuproject/references/upstream-map.md
+++ b/skills/mikuproject/references/upstream-map.md
@@ -13,6 +13,12 @@ Use this reference when you need the exact vendored `mikuproject` locations behi
 
 - `vendor/mikuproject/docs/mikuproject-ai-json-spec.md`
   - canonical AI JSON prompt/spec document
+- `MS Project XML`
+  - imported through `__mikuprojectCoreApi.msProject.importFromXml()`
+  - exported through `__mikuprojectCoreApi.msProject.exportToXml()`
+- workbook `XLSX`
+  - handled through `__mikuprojectCoreApi.xlsx.*`
+  - or `__mikuprojectCoreApi.importExternal(...)`
 - `project_draft_view`
   - imported through `__mikuprojectCoreApi.importAiJsonDocument()` or `importAiJsonText()`
 - `Patch JSON`
@@ -32,6 +38,10 @@ Use this reference when you need the exact vendored `mikuproject` locations behi
   - contains workbook JSON import/export
 - `vendor/mikuproject/src/ts/project-patch-json.ts`
   - contains Patch JSON validation and apply logic
+- `vendor/mikuproject/src/ts/project-xlsx.ts`
+  - contains structural workbook `XLSX` import/export
+- `vendor/mikuproject/src/ts/excel-io.ts`
+  - contains workbook binary encode/decode
 
 ## Working Assumption
 

--- a/skills/mikuproject/references/workbook-import-export.md
+++ b/skills/mikuproject/references/workbook-import-export.md
@@ -1,0 +1,73 @@
+# Workbook JSON Import/Export
+
+Use this reference when the user wants file-style import/export around `mikuproject_workbook_json`.
+
+This is different from the Phase A handoff use case because the focus here is primary file workflow.
+
+## Upstream API
+
+Prefer these functions:
+
+- `__mikuprojectCoreApi.workbookJson.exportDocument(model)`
+- `__mikuprojectCoreApi.workbookJson.importAsProjectModel(documentLike)`
+- `__mikuprojectCoreApi.workbookJson.importIntoProjectModel(documentLike, baseModel)`
+- `__mikuprojectCoreApi.workbookJson.validateDocument(documentLike)`
+
+## `workbook-import`
+
+Purpose:
+
+- replace the current state from a workbook JSON document
+
+Processing order:
+
+1. accept workbook JSON
+2. validate it when useful
+3. import it with `workbookJson.importAsProjectModel`
+4. export it again with `workbookJson.exportDocument`
+5. return the normalized `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying the workbook JSON was accepted or rejected
+- warnings, if any
+- the resulting `mikuproject_workbook_json`
+
+## `workbook-merge-import`
+
+Purpose:
+
+- apply workbook JSON changes onto an existing state
+
+Processing order:
+
+1. require the current workbook state
+2. rebuild `baseModel` from the current state
+3. call `workbookJson.importIntoProjectModel(documentLike, baseModel)`
+4. export the resulting model with `workbookJson.exportDocument`
+5. return the updated `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying the workbook JSON merge was applied or rejected
+- warnings, if any
+- short change summary
+- the updated `mikuproject_workbook_json`
+
+## `workbook-export`
+
+Purpose:
+
+- return the current state as `mikuproject_workbook_json`
+
+Processing order:
+
+1. require the current state
+2. if needed, rebuild `ProjectModel`
+3. export it with `workbookJson.exportDocument`
+4. return the resulting `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying this is the current workbook JSON export
+- the resulting `mikuproject_workbook_json`

--- a/skills/mikuproject/references/xlsx-import-export.md
+++ b/skills/mikuproject/references/xlsx-import-export.md
@@ -1,0 +1,95 @@
+# XLSX Import/Export
+
+Use this reference when the user wants to move between workbook `XLSX` and the current `mikuproject` state.
+
+This reference is for the structural workbook `XLSX`, not `WBS XLSX`.
+
+## Upstream API
+
+Prefer these functions:
+
+- `__mikuprojectCoreApi.xlsx.decodeWorkbook(bytes)`
+- `__mikuprojectCoreApi.xlsx.encodeWorkbook(workbook)`
+- `__mikuprojectCoreApi.xlsx.exportWorkbook(model)`
+- `__mikuprojectCoreApi.xlsx.importAsProjectModel(workbook)`
+- `__mikuprojectCoreApi.xlsx.importIntoProjectModel(workbook, baseModel)`
+- `__mikuprojectCoreApi.importExternal(...)`
+
+## `xlsx-import`
+
+Purpose:
+
+- read workbook `XLSX`
+- normalize it into the skill state
+- return `mikuproject_workbook_json`
+
+Processing order:
+
+1. accept `.xlsx` bytes
+2. for replace import, use either:
+   - `xlsx.decodeWorkbook(bytes)` then `xlsx.importAsProjectModel(workbook)`
+   - or `importExternal({ source: { format: "xlsx", bytes }, mode: "replace" })`
+3. validate the resulting `ProjectModel` when useful
+4. export it with `workbookJson.exportDocument`
+5. return the resulting `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying the workbook `XLSX` was accepted or rejected
+- warnings, if any
+- the resulting `mikuproject_workbook_json`
+
+## `xlsx-merge-import`
+
+Purpose:
+
+- apply workbook `XLSX` edits onto an existing state
+
+Processing order:
+
+1. require the current workbook state
+2. rebuild `baseModel` from the current state
+3. call `importExternal({ source: { format: "xlsx", bytes }, mode: "merge", baseModel })`
+4. export the resulting model with `workbookJson.exportDocument`
+5. return the updated `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying the workbook `XLSX` merge was applied or rejected
+- warnings, if any
+- short change summary
+- the updated `mikuproject_workbook_json`
+
+## `xlsx-export`
+
+Purpose:
+
+- take the current state
+- return structural workbook `XLSX`
+
+Processing order:
+
+1. require the current state
+2. rebuild `ProjectModel` from `mikuproject_workbook_json` if needed
+3. create workbook data with `xlsx.exportWorkbook(model)`
+4. encode it with `xlsx.encodeWorkbook(workbook)`
+5. return the bytes as the export result
+
+Response shape:
+
+- one short line saying this is the current workbook `XLSX`
+- workbook sheet summary, when useful
+- the generated `.xlsx` bytes or file artifact
+
+## Errors
+
+Hard errors:
+
+- `.xlsx` bytes cannot be decoded
+- current state is missing for export or merge import
+
+Soft errors:
+
+- unsupported workbook edits are ignored
+- partial changes are applied
+- validation returns warnings

--- a/skills/mikuproject/references/xml-import-export.md
+++ b/skills/mikuproject/references/xml-import-export.md
@@ -1,0 +1,67 @@
+# XML Import/Export
+
+Use this reference when the user wants to move between `MS Project XML` and the current `mikuproject` state.
+
+## Upstream API
+
+Prefer these functions:
+
+- `__mikuprojectCoreApi.msProject.importFromXml(xmlText)`
+- `__mikuprojectCoreApi.msProject.exportToXml(model)`
+
+## `xml-import`
+
+Purpose:
+
+- read `MS Project XML`
+- normalize it into the skill state
+- return `mikuproject_workbook_json`
+
+Processing order:
+
+1. accept XML text
+2. import it with `msProject.importFromXml`
+3. validate the resulting `ProjectModel` when useful
+4. export it with `workbookJson.exportDocument`
+5. return the resulting `mikuproject_workbook_json`
+
+Response shape:
+
+- one short line saying the XML was accepted or rejected
+- warnings, if any
+- the resulting `mikuproject_workbook_json`
+
+Notes:
+
+- treat this as a replace import
+- do not pretend XML merge import exists in the current design
+
+## `xml-export`
+
+Purpose:
+
+- take the current state
+- return `MS Project XML`
+
+Processing order:
+
+1. require the current state
+2. rebuild `ProjectModel` from `mikuproject_workbook_json` if needed
+3. export XML with `msProject.exportToXml`
+4. return the XML text
+
+Response shape:
+
+- one short line saying this is the current XML export
+- the generated XML text
+
+## Errors
+
+Hard errors:
+
+- XML text cannot be parsed
+- current state is missing for export
+
+Soft errors:
+
+- model validation returns warnings

--- a/tests/mikuproject-phase-b-smoke.test.js
+++ b/tests/mikuproject-phase-b-smoke.test.js
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+function readVendored(relativePath) {
+  return readFileSync(path.resolve(ROOT, "vendor/mikuproject", relativePath), "utf8");
+}
+
+const typesCode = readVendored("src/js/types.js");
+const aiJsonUtilCode = readVendored("src/js/ai-json-util.js");
+const aiJsonSpecCode = readVendored("src/js/ai-json-spec.js");
+const msProjectXmlCode = readVendored("src/js/msproject-xml.js");
+const projectWorkbookSchemaCode = readVendored("src/js/project-workbook-schema.js");
+const excelIoCode = readVendored("src/js/excel-io.js");
+const projectXlsxCode = readVendored("src/js/project-xlsx.js");
+const projectWorkbookJsonCode = readVendored("src/js/project-workbook-json.js");
+const projectPatchJsonCode = readVendored("src/js/project-patch-json.js");
+const coreApiCode = readVendored("src/js/core-api.js");
+const dependencyXml = readVendored("testdata/dependency.xml");
+
+function bootModules() {
+  new Function([
+    typesCode,
+    aiJsonUtilCode,
+    aiJsonSpecCode,
+    msProjectXmlCode,
+    projectWorkbookSchemaCode,
+    excelIoCode,
+    projectXlsxCode,
+    projectWorkbookJsonCode,
+    projectPatchJsonCode,
+    coreApiCode
+  ].join("\n"))();
+  return globalThis.__mikuprojectCoreApi;
+}
+
+describe("mikuproject phase b smoke", () => {
+  beforeEach(() => {
+    delete globalThis.__mikuprojectAiJsonUtil;
+    delete globalThis.__mikuprojectAiJsonSpec;
+    delete globalThis.__mikuprojectXml;
+    delete globalThis.__mikuprojectProjectWorkbookSchema;
+    delete globalThis.__mikuprojectExcelIo;
+    delete globalThis.__mikuprojectProjectXlsx;
+    delete globalThis.__mikuprojectProjectWorkbookJson;
+    delete globalThis.__mikuprojectProjectPatchJson;
+    delete globalThis.__mikuprojectCoreApi;
+  });
+
+  it("supports xml import/export, workbook import/export, and xlsx import/export", () => {
+    const api = bootModules();
+
+    const xmlImportedModel = api.msProject.importFromXml(dependencyXml);
+    const xmlImportedWorkbook = api.workbookJson.exportDocument(xmlImportedModel);
+    expect(xmlImportedWorkbook.format).toBe("mikuproject_workbook_json");
+
+    const xmlExported = api.msProject.exportToXml(xmlImportedModel);
+    expect(xmlExported).toContain("<Project");
+
+    const workbookReplaced = api.workbookJson.importAsProjectModel(xmlImportedWorkbook);
+    expect(workbookReplaced.model.project.name).toBe(xmlImportedModel.project.name);
+
+    const workbookDocument = structuredClone(xmlImportedWorkbook);
+    workbookDocument.sheets.Project.find((row) => row.Field === "Name").Value = "Phase B Workbook Merge";
+    const workbookMerged = api.workbookJson.importIntoProjectModel(workbookDocument, xmlImportedModel);
+    expect(workbookMerged.model.project.name).toBe("Phase B Workbook Merge");
+    expect(Array.isArray(workbookMerged.changes)).toBe(true);
+
+    const xlsxWorkbook = api.xlsx.exportWorkbook(xmlImportedModel);
+    xlsxWorkbook.sheets
+      .find((sheet) => sheet.name === "Project")
+      .rows.find((row) => row.cells[0]?.value === "Name")
+      .cells[1].value = "Phase B Xlsx Replace";
+    const xlsxBytes = api.xlsx.encodeWorkbook(xlsxWorkbook);
+    const xlsxDecoded = api.xlsx.decodeWorkbook(xlsxBytes);
+    const xlsxReplacedModel = api.xlsx.importAsProjectModel(xlsxDecoded);
+    const xlsxMergedModel = api.xlsx.importIntoProjectModel(xlsxDecoded, xmlImportedModel);
+
+    expect(xlsxBytes).toBeInstanceOf(Uint8Array);
+    expect(xlsxReplacedModel.project.name).toBe("Phase B Xlsx Replace");
+    expect(xlsxMergedModel.project.name).toBe("Phase B Xlsx Replace");
+  });
+});


### PR DESCRIPTION
## 概要

`mikuproject` skill に Phase B の primary file import/export workflow を反映しました。 あわせて、`MS Project XML`、構造忠実 workbook `XLSX`、`mikuproject_workbook_json` 向けの reference を追加し、root の `build` スクリプトと Phase B 向け smoke test を整備しています。

## 変更内容

- `skills/mikuproject/SKILL.md` を更新
  - AI JSON workflow に加えて、Phase B の file workflow を記述
  - `xml-import` / `xml-export`
  - `xlsx-import` / `xlsx-merge-import` / `xlsx-export`
  - `workbook-import` / `workbook-merge-import` / `workbook-export`
  - `validation checks` という表現へ整理
- `skills/mikuproject/references/` に Phase B 向け文書を追加
  - `xml-import-export.md`
  - `xlsx-import-export.md`
  - `workbook-import-export.md`
  - `phase-b-examples.md`
- `skills/mikuproject/references/upstream-map.md` を更新
  - `MS Project XML`
  - workbook `XLSX`
  - `excel-io.ts`
  - `project-xlsx.ts` への導線を追加
- `tests/mikuproject-phase-b-smoke.test.js` を追加
  - `xml import/export`
  - `workbook import/export`
  - `xlsx import/export` の薄い smoke test を追加
- `package.json` に `build` script を追加
  - `build: npm test`
- `README.md` を更新
  - Phase B の primary file workflow を日英で追記
- `TODO.md` を更新
  - Phase B の import/export 支援を完了扱いに更新
  - `SKILL.md` 反映と short examples 追加を完了扱いに更新
- `docs/agent-skill-design.md` の表現を更新
  - `validator` ではなく `validation check` に修正

## 意図

- skill 文書を Phase A だけでなく Phase B の file workflow まで含めて一貫させる
- `MS Project XML` / `XLSX` / `mikuproject_workbook_json` の扱い方を reference として分離する
- root から `npm run build` を実行できる状態にする
- Phase B の最小確認を smoke test で押さえる

## 確認できること

このコミット差分から確認できる内容は以下です。

- Phase B の file workflow が `skills/mikuproject/SKILL.md` に反映された
- `xml/xlsx/workbook` 向けの reference 文書が追加された
- root に `tests/mikuproject-phase-b-smoke.test.js` が追加された
- `package.json` に `build` script が追加された
- README と TODO が Phase B の進捗に合わせて更新された

## 補足

- このコミットで追加している `XLSX` は、`WBS XLSX` ではなく構造忠実 workbook `XLSX` を対象にしています