### PR TITLE
Phase C の report 出力に関する詳細仕様メモと upstream API 提案書を追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -153,6 +153,15 @@
 - [ ] `Markdown` 出力支援
 - [ ] `Mermaid` 出力支援
 
+設計メモ:
+
+- [x] `docs/phase-c-wbs-xlsx-workflow.md` に `WBS XLSX` 詳細仕様メモを作成する
+- [x] `docs/upstream-wbs-xlsx-api-proposal.md` に upstream 相談メモを作成する
+- [x] `docs/phase-c-svg-workflow.md` に `SVG` 詳細仕様メモを作成する
+- [x] `docs/upstream-svg-api-proposal.md` に upstream 相談メモを作成する
+- [x] `docs/phase-c-markdown-mermaid-workflow.md` に `Markdown / Mermaid` 詳細仕様メモを作成する
+- [x] `docs/upstream-markdown-mermaid-api-proposal.md` に upstream 相談メモを作成する
+
 ### Other Future Candidates
 
 - [ ] MCP 対応

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,14 @@
 - Phase B 詳細: [phase-b-msproject-xml-workflow.md](./phase-b-msproject-xml-workflow.md)
 - Phase B 詳細: [phase-b-workbook-json-workflow.md](./phase-b-workbook-json-workflow.md)
 - Phase B 詳細: [phase-b-xlsx-workflow.md](./phase-b-xlsx-workflow.md)
+- Phase C 詳細: [phase-c-wbs-xlsx-workflow.md](./phase-c-wbs-xlsx-workflow.md)
+- Phase C 詳細: [phase-c-svg-workflow.md](./phase-c-svg-workflow.md)
+- Phase C 詳細: [phase-c-markdown-mermaid-workflow.md](./phase-c-markdown-mermaid-workflow.md)
+- upstream 総論メモ: [upstream-phase-c-report-api-proposal.md](./upstream-phase-c-report-api-proposal.md)
 - upstream 相談メモ: [upstream-xlsx-api-proposal.md](./upstream-xlsx-api-proposal.md)
+- upstream 相談メモ: [upstream-wbs-xlsx-api-proposal.md](./upstream-wbs-xlsx-api-proposal.md)
+- upstream 相談メモ: [upstream-svg-api-proposal.md](./upstream-svg-api-proposal.md)
+- upstream 相談メモ: [upstream-markdown-mermaid-api-proposal.md](./upstream-markdown-mermaid-api-proposal.md)
 - 実装 TODO: [../TODO.md](../TODO.md)
 
 ## subtree 運用

--- a/docs/phase-c-markdown-mermaid-workflow.md
+++ b/docs/phase-c-markdown-mermaid-workflow.md
@@ -1,0 +1,154 @@
+# Phase C Detail: Markdown and Mermaid Outputs
+
+この文書は、Phase C の詳細仕様メモとして、
+`WBS Markdown` と `Mermaid` 出力を整理したものです。
+
+## 対象
+
+- `WBS Markdown`
+- `Mermaid Markdown`
+
+この段階では、`WBS記述書 Markdown` などの派生 Markdown は対象外とする。
+
+## 位置づけ
+
+`WBS Markdown` と `Mermaid` は、Phase B の主要交換形式ではなく、
+report / presentation output として扱う。
+
+- `WBS Markdown`: 人が読むための軽量テキスト共有用
+- `Mermaid`: 設計資料や Markdown へ貼るための軽量 gantt 表現
+
+## upstream 実装資産
+
+少なくとも次は確認できている。
+
+### `WBS Markdown`
+
+- `vendor/mikuproject/src/js/wbs-markdown.js`
+  - `globalThis.__mikuprojectWbsMarkdown.exportWbsMarkdown`
+
+### `Mermaid`
+
+- `vendor/mikuproject/src/js/msproject-xml.js`
+  - `exportMermaidGantt(model)`
+
+### UI 側導線
+
+- `vendor/mikuproject/src/js/main.js`
+  - `downloadCurrentWbsMarkdown`
+  - `downloadCurrentMermaidMarkdown`
+
+### test
+
+- `vendor/mikuproject/tests/mikuproject-wbs-markdown.test.js`
+- `vendor/mikuproject/tests/mikuproject-main-preview-export.test.js`
+
+## `mikuproject-skills` 側の基本方針
+
+基本方針としては、`mikuproject` 側で `core API` を用意してもらい、
+それを `mikuproject-skills` から呼ぶ形が望ましい。
+
+理由:
+
+- `WBS Markdown` と `Mermaid` は report 系出力であり、`WBS XLSX` / `SVG` と並ぶ
+- 現状は low-level global や XML module の関数として分散している
+- skills 側で直接組み始めるより、upstream 側で公開面を揃えたほうが今後の拡張に強い
+
+## 想定操作
+
+最初の候補は次の 2 つ。
+
+- `wbs-markdown-export`
+- `mermaid-export`
+
+## 入力
+
+- current state
+
+前提:
+
+- current state は `mikuproject_workbook_json` または `ProjectModel`
+
+## 処理
+
+### `wbs-markdown-export`
+
+1. current state を `ProjectModel` に揃える
+2. export option を決める
+3. upstream API で `WBS Markdown` 文字列を生成する
+4. Markdown 文字列を返す
+
+### `mermaid-export`
+
+1. current state を `ProjectModel` に揃える
+2. upstream API で Mermaid gantt text を生成する
+3. Mermaid gantt text をそのまま返す
+
+## option 論点
+
+`WBS Markdown` では、少なくとも次が論点になる。
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+- `useBusinessDaysForProgressBand`
+
+`Mermaid` では first cut では option をほぼ持たず、
+まず既定 export を成立させるので十分。
+
+また、`WBS Markdown` では
+`WBS XLSX` と意味が近い option 名を共通語彙に寄せるのが望ましい。
+
+候補:
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+## 出力
+
+### `wbs-markdown-export`
+
+- one short line saying this is the current `WBS Markdown`
+- generated Markdown text
+
+### `mermaid-export`
+
+- one short line saying this is the current Mermaid export
+- generated Mermaid gantt text
+
+## エラー方針
+
+### hard error
+
+- current state がない
+- export 結果が空
+
+### soft error
+
+- option の一部が既定値へ丸められる
+- Markdown / Mermaid の表現上、一部情報が簡略化される
+
+## upstream 相談前提
+
+`WBS Markdown` は `__mikuprojectWbsMarkdown`、
+`Mermaid` は `msproject-xml` の export 関数にあるが、
+どちらも `__mikuprojectCoreApi` には載っていない。
+
+そのため、`mikuproject-skills` 側では
+low-level global や XML module を直接使う前に、まず upstream 側へ次を相談する前提とする。
+
+- `WBS Markdown` export の core API 化
+- `Mermaid` export の core API 化
+- report 系出力の公開面整理
+
+## 検証根拠
+
+少なくとも次は確認できている。
+
+- `wbs-markdown.js` に `exportWbsMarkdown` がある
+- `msproject-xml.js` に `exportMermaidGantt` がある
+- `main.js` に `WBS Markdown` と `Mermaid Markdown` の保存導線がある
+- `mikuproject-wbs-markdown.test.js` に `WBS Markdown` の test がある

--- a/docs/phase-c-svg-workflow.md
+++ b/docs/phase-c-svg-workflow.md
@@ -1,0 +1,168 @@
+# Phase C Detail: SVG Outputs
+
+この文書は、Phase C の詳細仕様メモとして、
+`SVG` 系出力を整理したものです。
+
+## 対象
+
+この段階で対象にするのは次の 3 系統。
+
+- `Daily SVG`
+- `Weekly SVG`
+- `Monthly Calendar SVG`
+
+この文書では `Mermaid` は別扱いとし、
+まず `SVG` ファイル取得に絞る。
+
+## 位置づけ
+
+`SVG` 系出力は、Phase B の主要交換形式ではなく、
+report / presentation output として扱う。
+
+`WBS XLSX` と同じく、ProjectModel から派生表示を生成する出力である。
+
+## upstream 実装資産
+
+少なくとも次は確認できている。
+
+### low-level export
+
+- `vendor/mikuproject/src/ts/wbs-svg.ts`
+  - `globalThis.__mikuprojectNativeSvg.exportNativeSvg`
+  - `globalThis.__mikuprojectNativeSvg.exportWeeklyNativeSvg`
+  - `globalThis.__mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive`
+
+### UI 側導線
+
+- `vendor/mikuproject/src/ts/main.ts`
+  - `downloadSvgBtn` 相当の daily SVG 保存処理
+  - weekly SVG 保存処理
+  - monthly calendar SVG ZIP 保存処理
+
+### test
+
+- `vendor/mikuproject/tests/mikuproject-main-preview-export.test.js`
+- `vendor/mikuproject/tests/mikuproject-main-preview-svg.test.js`
+
+## `mikuproject-skills` 側の基本方針
+
+基本方針としては、`mikuproject` 側で `core API` を用意してもらい、
+それを `mikuproject-skills` から呼ぶ形が望ましい。
+
+理由:
+
+- `SVG` は派生表示であり、今後も表示仕様の変更が入りやすい
+- low-level global を skill 側で直接組み始めると、
+  option や返り値の意味づけが skill 側へ漏れる
+- `Daily / Weekly / Monthly` をまとめて公開面整理したほうが、
+  `WBS XLSX` や `Markdown` と並べやすい
+
+## 想定操作
+
+最初の候補は次の 3 つ。
+
+- `daily-svg-export`
+- `weekly-svg-export`
+- `monthly-calendar-svg-export`
+
+## 入力
+
+- current state
+
+前提:
+
+- current state は `mikuproject_workbook_json` または `ProjectModel`
+
+## 処理
+
+### `daily-svg-export`
+
+1. current state を `ProjectModel` に揃える
+2. export option を決める
+3. upstream API で daily SVG 文字列を生成する
+4. SVG 文字列を返す
+
+### `weekly-svg-export`
+
+1. current state を `ProjectModel` に揃える
+2. export option を決める
+3. upstream API で weekly SVG 文字列を生成する
+4. SVG 文字列を返す
+
+### `monthly-calendar-svg-export`
+
+1. current state を `ProjectModel` に揃える
+2. upstream API で月別 SVG entries を生成する
+3. 月別 SVG 群として返す
+
+## option 論点
+
+現時点では、少なくとも次が論点になる。
+
+- 表示期間
+- holiday / business day の扱い
+- label mode
+- monthly calendar を月別 entries としてどう返すか
+
+first cut では、skill 側で option を増やしすぎず、
+既定 export をまず成立させるのが妥当。
+
+また、全 SVG export で options を完全統一するより、
+意味が近いものだけ共通語彙に寄せる方針が妥当。
+
+候補:
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+## 出力
+
+### `daily-svg-export`
+
+- one short line saying this is the current daily SVG
+- generated SVG text
+
+### `weekly-svg-export`
+
+- one short line saying this is the current weekly SVG
+- generated SVG text
+
+### `monthly-calendar-svg-export`
+
+- one short line saying this is the monthly calendar SVG export
+- generated monthly SVG entries
+
+## エラー方針
+
+### hard error
+
+- current state がない
+- SVG 生成結果が空
+- monthly entries を生成できない
+
+### soft error
+
+- export option の一部が既定値へ丸められる
+- preview 向け既定と file export 向け既定の差がある
+
+## upstream 相談前提
+
+`SVG` 系は現状 `__mikuprojectNativeSvg` にあるが、
+`__mikuprojectCoreApi` には載っていない。
+
+そのため、`mikuproject-skills` 側では
+low-level global を直接使う前に、まず upstream 側へ次を相談する前提とする。
+
+- `Daily / Weekly / Monthly Calendar SVG` export の core API 化
+- option の公開面整理
+- monthly calendar entries の返り値の整理
+
+## 検証根拠
+
+少なくとも次は確認できている。
+
+- `wbs-svg.ts` に daily / weekly / monthly calendar の export 実装がある
+- `main.ts` に各出力の download 導線がある
+- preview/export 系 test に SVG 保存の確認がある

--- a/docs/phase-c-wbs-xlsx-workflow.md
+++ b/docs/phase-c-wbs-xlsx-workflow.md
@@ -1,0 +1,134 @@
+# Phase C Detail: WBS XLSX Export
+
+この文書は、Phase C の最初の詳細仕様として、
+`WBS XLSX` の export workflow を整理したものです。
+
+## 対象
+
+- `WBS XLSX` の export
+
+この段階では import は扱わない。
+
+## 位置づけ
+
+`WBS XLSX` は、`MS Project XML` や構造忠実 workbook `XLSX` と異なり、
+主要交換形式ではなく report / presentation output として扱う。
+
+したがって、Phase B の primary file workflow とは分けて考える。
+
+## upstream 実装資産
+
+少なくとも次は確認できている。
+
+### low-level export
+
+- `vendor/mikuproject/src/ts/wbs-xlsx.ts`
+  - `globalThis.__mikuprojectWbsXlsx.exportWbsWorkbook`
+  - `globalThis.__mikuprojectWbsXlsx.collectWbsHolidayDates`
+
+### binary encode
+
+- `vendor/mikuproject/src/ts/excel-io.ts`
+  - `globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec`
+
+### UI 側導線
+
+- `vendor/mikuproject/src/ts/main.ts`
+  - `exportCurrentWbsXlsx`
+  - `buildCurrentWbsOptions(model)`
+
+### test
+
+- `vendor/mikuproject/tests/mikuproject-wbs-xlsx.test.js`
+- `vendor/mikuproject/tests/mikuproject-main-preview-export.test.js`
+
+## `mikuproject-skills` 側の基本方針
+
+基本方針としては、`mikuproject` 側で `core API` を用意してもらい、
+それを `mikuproject-skills` から呼ぶ形が望ましい。
+
+理由:
+
+- `WBS XLSX` は派生表示であり、今後 `Markdown` / `SVG` / `Mermaid` と並ぶ可能性が高い
+- low-level global を skill 側で直接組み合わせ始めると責務が散りやすい
+- upstream 側で options の意味を揃えたほうが、後続の report 系展開にも効く
+
+## 想定操作
+
+最初は次の 1 操作で十分。
+
+- `wbs-xlsx-export`
+
+## 入力
+
+- current state
+
+前提:
+
+- current state は `mikuproject_workbook_json` または `ProjectModel`
+- report 出力なので baseModel は不要
+
+## 処理
+
+1. current state を `ProjectModel` に揃える
+2. `WBS XLSX` export 用 options を決める
+3. upstream API で workbook-like object を生成する
+4. `.xlsx` bytes に encode する
+5. export 結果を返す
+
+## option 論点
+
+upstream 側の `WBS XLSX` には少なくとも次の option が見える。
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+`mikuproject-skills` の first cut では、option は最小限に絞るのが妥当。
+
+候補:
+
+- 何も指定しない既定 export
+- `holidayDates`
+- 表示期間の前後日数
+
+## 出力
+
+- one short line saying this is the current `WBS XLSX`
+- option summary, when useful
+- generated `.xlsx` bytes or file artifact
+
+## エラー方針
+
+### hard error
+
+- current state がない
+- `WBS XLSX` 用 workbook の生成に失敗する
+- `.xlsx` encode に失敗する
+
+### soft error
+
+- 祝日や表示期間 option の一部が既定値へ丸められる
+- upstream 側の表示用補正により、意図どおりに見えない可能性がある
+
+## upstream 相談前提
+
+`WBS XLSX` は現状 `__mikuprojectWbsXlsx` にあるが、
+`__mikuprojectCoreApi` には載っていない。
+
+そのため、`mikuproject-skills` 側では
+low-level global を直接使う前に、まず upstream 側へ次を相談する前提とする。
+
+- `WBS XLSX` export の core API 化
+- option の公開面整理
+- `WBS XLSX` を Phase C の他出力とどう並べるか
+
+## 検証根拠
+
+少なくとも次は確認できている。
+
+- `wbs-xlsx.ts` に `exportWbsWorkbook` がある
+- `excel-io.ts` で `.xlsx` bytes へ encode できる
+- `main.ts` に `exportCurrentWbsXlsx` がある
+- `mikuproject-wbs-xlsx.test.js` で表示帯、祝日、表示期間 option がテストされている

--- a/docs/upstream-markdown-mermaid-api-proposal.md
+++ b/docs/upstream-markdown-mermaid-api-proposal.md
@@ -1,0 +1,127 @@
+# Proposal for `mikuproject`: Markdown and Mermaid core API
+
+この文書は、`mikuproject-skills` から見た
+`mikuproject` upstream への相談メモです。
+
+## 背景
+
+`mikuproject-skills` では Phase C として、
+report / presentation outputs を skill から扱いたい。
+
+その中で、`WBS Markdown` と `Mermaid` についても
+upstream 側の API 公開面を整理したい。
+
+対象:
+
+- `WBS Markdown`
+- `Mermaid`
+
+## 現状確認できている実装資産
+
+### `WBS Markdown`
+
+- `src/js/wbs-markdown.js`
+  - `__mikuprojectWbsMarkdown.exportWbsMarkdown`
+
+### `Mermaid`
+
+- `src/js/msproject-xml.js`
+  - `exportMermaidGantt(model)`
+
+### UI 側導線
+
+- `src/js/main.js`
+  - `downloadCurrentWbsMarkdown`
+  - `downloadCurrentMermaidMarkdown`
+
+## 相談したいこと
+
+`WBS Markdown` と `Mermaid` についても、
+`mikuproject-skills` から扱いやすい `core API` 入口を追加できないか相談したい。
+
+## 相談理由
+
+### 1. report 系出力を `core API` 前提で揃えたい
+
+`XLSX` と同様に、skills 側では可能な限り upstream API を入口にしたい。
+
+### 2. `WBS XLSX` / `SVG` / `Markdown` / `Mermaid` を同じ層で整理したい
+
+report 系出力は今後並列に扱う見込みがあるため、
+公開面を upstream 側で揃えたほうが扱いやすい。
+
+### 3. `Mermaid` は現状 XML module 側にあり、責務が散っている
+
+`Mermaid` 出力自体は意味的に自然だが、
+skills 側から見ると `core API` 経由で呼べたほうが分かりやすい。
+
+### 4. `Mermaid` の presentation 層責務は upstream に持たせすぎない
+
+`Mermaid` については、fenced Markdown まで upstream が返すより、
+Mermaid gantt text をそのまま返すほうが責務分離が明確である。
+
+fence を付けるかどうかは、
+skills / CLI / docs 側で決めればよい。
+
+## 提案したい方向性
+
+API 名は例であり、確定ではない。
+
+```ts
+globalThis.__mikuprojectCoreApi.report = {
+  markdown: {
+    exportWbs(model, options)
+  },
+  mermaid: {
+    exportGantt(model)
+  }
+};
+```
+
+あるいは、より単純に:
+
+```ts
+globalThis.__mikuprojectCoreApi.wbsMarkdown = {
+  export(model, options)
+};
+
+globalThis.__mikuprojectCoreApi.mermaid = {
+  exportGantt(model)
+};
+```
+
+## 最小提案
+
+最小構成としては、まず次でもよい。
+
+- `report.markdown.exportWbs(model, options)`
+- `report.mermaid.exportGantt(model)`
+
+## option 方針
+
+`WBS Markdown` では、
+`WBS XLSX` と意味が近い option 名は共通語彙に寄せたい。
+
+候補:
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+ただし、`useBusinessDaysForProgressBand` のような
+`WBS Markdown` 固有の表現は個別 option でよい。
+
+`Mermaid` は first cut では option をほぼ持たず、
+既定 export のみをまず core API 化するのが妥当と考える。
+
+## `mikuproject-skills` 側の想定ユースケース
+
+- current state を `ProjectModel` に戻す
+- `WBS Markdown` をテキストとして返す
+- `Mermaid` を gantt text として返す
+
+## 補足
+
+- この相談は `WBS記述書 Markdown` のような次段の派生出力は含まない
+- まずは `WBS Markdown` と `Mermaid` の basic export を対象にする

--- a/docs/upstream-phase-c-report-api-proposal.md
+++ b/docs/upstream-phase-c-report-api-proposal.md
@@ -1,0 +1,171 @@
+# Proposal for `mikuproject`: Phase C report output core APIs
+
+この文書は、`mikuproject-skills` から見た
+`mikuproject` upstream への Phase C 総論メモです。
+
+## 背景
+
+`mikuproject-skills` では、次段として
+report / presentation outputs を skill から扱いたい。
+
+対象は次の 3 系統である。
+
+- `WBS XLSX`
+- `SVG`
+  - `Daily SVG`
+  - `Weekly SVG`
+  - `Monthly Calendar SVG`
+- `Markdown / Mermaid`
+  - `WBS Markdown`
+  - `Mermaid gantt`
+
+## 相談したいこと
+
+これらの Phase C 出力についても、
+`mikuproject-skills` から扱いやすい `core API` 公開面を upstream 側で整理できないか相談したい。
+
+## 基本方針
+
+`mikuproject-skills` 側では、
+low-level global を直接組み合わせるよりも、
+`mikuproject` の `core API` を呼ぶ構成に寄せたい。
+
+理由:
+
+- Phase B では、主要交換形式を `core API` 前提で整理できた
+- Phase C でも同じ方針に揃えたほうが skill 側の責務が増えにくい
+- report 系出力は今後も拡張されやすく、upstream 側で公開面を持つ価値が高い
+
+## 今回まとめて相談したい対象
+
+### 1. `WBS XLSX`
+
+現状:
+
+- `__mikuprojectWbsXlsx.exportWbsWorkbook`
+- `__mikuprojectWbsXlsx.collectWbsHolidayDates`
+
+相談メモ:
+
+- [upstream-wbs-xlsx-api-proposal.md](./upstream-wbs-xlsx-api-proposal.md)
+
+### 2. `SVG`
+
+現状:
+
+- `__mikuprojectNativeSvg.exportNativeSvg`
+- `__mikuprojectNativeSvg.exportWeeklyNativeSvg`
+- `__mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive`
+
+相談メモ:
+
+- [upstream-svg-api-proposal.md](./upstream-svg-api-proposal.md)
+
+### 3. `Markdown / Mermaid`
+
+現状:
+
+- `__mikuprojectWbsMarkdown.exportWbsMarkdown`
+- `exportMermaidGantt(model)`
+
+相談メモ:
+
+- [upstream-markdown-mermaid-api-proposal.md](./upstream-markdown-mermaid-api-proposal.md)
+
+## 提案したい方向性
+
+API 名は例であり、確定ではない。
+
+```ts
+globalThis.__mikuprojectCoreApi.report = {
+  wbsXlsx: {
+    exportWorkbook(model, options),
+    encodeWorkbook(workbook),
+    collectHolidayDates(model)
+  },
+  svg: {
+    exportDaily(model, options),
+    exportWeekly(model, options),
+    exportMonthlyCalendarEntries(model, options)
+  },
+  markdown: {
+    exportWbs(model, options)
+  },
+  mermaid: {
+    exportGantt(model)
+  }
+};
+```
+
+## なぜまとめて相談するのか
+
+この 3 系統は、実装場所は分かれているが、
+意味としては同じ `Phase C report outputs` である。
+
+別々に相談するより、少なくとも次を upstream 側でまとめて判断しやすい。
+
+- `core API` に report 系の層を持つか
+- `WBS XLSX` / `SVG` / `Markdown` / `Mermaid` をどの粒度で並べるか
+- option の公開面をどこまで共通語彙で揃えるか
+
+## option 方針
+
+first cut では、全 export の options を無理に完全統一するよりも、
+意味が近いものに共通の名前を与える方針が妥当と考える。
+
+たとえば次のような軸は、複数出力で共通化しやすい。
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+一方で、出力固有の責務は個別 option のままでよい。
+
+- `WBS XLSX` 固有の workbook / encode 周辺
+- `SVG` 固有の weekly / monthly 表示調整
+- `WBS Markdown` 固有の progress band 表現
+- `Mermaid` 固有の軽量 text export
+
+したがって upstream には、
+
+- 同義の option をできるだけ同じ名前に寄せる
+- すべての export に同じ option shape を要求しない
+- first cut は各 export の既定動作を優先する
+
+という整理を期待したい。
+
+## monthly calendar の返り値方針
+
+`mikuproject-skills` 側では、
+`Monthly Calendar SVG` は ZIP bytes よりも
+月別 SVG を個別 entry として取得できるほうが望ましい。
+
+理由:
+
+- 生成AIとのやりとりでは、月別に分けて返せるほうが扱いやすい
+- skill 側で一部月のみ返す、要約する、といった制御がしやすい
+- GUI の download 導線と、API の返り値都合は分けて考えたほうが自然
+
+そのため、`core API` としては ZIP export よりも、
+まず `entries` ベースの返り値を優先したい。
+
+## Mermaid の返り値方針
+
+`Mermaid` については、
+upstream の責務は fenced Markdown 生成ではなく、
+Mermaid gantt text 自体の export に留めるのが妥当と考える。
+
+fence で包むかどうかは、skills / CLI / docs 側の presentation 層で扱えばよい。
+
+## `mikuproject-skills` 側の想定ユースケース
+
+- current state を `ProjectModel` に戻す
+- report 出力を生成する
+- `XLSX` / `SVG` / `Markdown` / `Mermaid` を利用者へ返す
+
+## 補足
+
+- この相談は Phase B の主要交換形式とは別系統の話である
+- `CSV` や AI 向け編集用 JSON は今回の相談対象外
+- 詳細は個別メモを参照しつつ、まずは「まとめて core API 化を検討できるか」を相談したい

--- a/docs/upstream-svg-api-proposal.md
+++ b/docs/upstream-svg-api-proposal.md
@@ -1,0 +1,132 @@
+# Proposal for `mikuproject`: SVG export core API
+
+この文書は、`mikuproject-skills` から見た
+`mikuproject` upstream への相談メモです。
+
+## 背景
+
+`mikuproject-skills` では Phase C として、
+report / presentation outputs を skill から扱いたい。
+
+その中でも、まず `SVG` ファイル取得について
+upstream 側の API 公開面を整理したい。
+
+対象:
+
+- `Daily SVG`
+- `Weekly SVG`
+- `Monthly Calendar SVG`
+
+## 現状確認できている実装資産
+
+### low-level export
+
+- `src/ts/wbs-svg.ts`
+  - `__mikuprojectNativeSvg.exportNativeSvg`
+  - `__mikuprojectNativeSvg.exportWeeklyNativeSvg`
+  - `__mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive`
+
+### UI 側導線
+
+- `src/ts/main.ts`
+  - daily SVG 保存
+  - weekly SVG 保存
+  - monthly calendar SVG ZIP 保存
+
+## 相談したいこと
+
+`SVG` 系出力についても、
+`mikuproject-skills` から扱いやすい `core API` 入口を追加できないか相談したい。
+
+## 相談理由
+
+### 1. `mikuproject-skills` 側は core API を前提にしたい
+
+Phase B で `xlsx` を `core API` に寄せたのと同様に、
+Phase C でも upstream API を入口にしたい。
+
+### 2. `Daily / Weekly / Monthly` の公開面を upstream 側で揃えたい
+
+現状は low-level global と UI 側導線はあるが、
+skill から扱うには公開面が散っている。
+
+### 3. monthly calendar は返り値の意味づけが重要
+
+`Monthly Calendar SVG` は単一の SVG ではなく、
+月ごとの複数 SVG として扱うのが自然である。
+
+これを
+
+- 月別 entries 配列として返すのか
+- GUI 保存用 ZIP は別レイヤで組み立てるのか
+
+は upstream 側で整理してもらうほうが自然である。
+
+`mikuproject-skills` 側としては、
+core API は ZIP bytes ではなく
+月別 SVG entries を返す形が望ましい。
+
+理由:
+
+- 生成AIとのやりとりでは月単位で扱えるほうが使いやすい
+- 一部月のみ返す、要約する、といった制御がしやすい
+- GUI の download 都合と API の返り値を分離できる
+
+## 提案したい方向性
+
+API 名は例であり、確定ではない。
+
+```ts
+globalThis.__mikuprojectCoreApi.report = {
+  svg: {
+    exportDaily(model, options),
+    exportWeekly(model, options),
+    exportMonthlyCalendarEntries(model, options)
+  }
+};
+```
+
+あるいは、より単純に:
+
+```ts
+globalThis.__mikuprojectCoreApi.svg = {
+  exportDaily(model, options),
+  exportWeekly(model, options),
+  exportMonthlyCalendarEntries(model, options)
+};
+```
+
+## 最小提案
+
+最小構成としては、まず次でもよい。
+
+- `svg.exportDaily(model, options)`
+- `svg.exportWeekly(model, options)`
+- `svg.exportMonthlyCalendarEntries(model, options)`
+
+## option 方針
+
+`SVG` 系でも、全出力で options を完全共通化するより、
+意味が近いものだけ共通語彙に寄せる方針が妥当と考える。
+
+候補:
+
+- `holidayDates`
+- `displayDaysBeforeBaseDate`
+- `displayDaysAfterBaseDate`
+- `useBusinessDaysForDisplayRange`
+
+一方で、daily / weekly / monthly の表示差に由来するものは、
+無理に 1 つの共通 shape に押し込めないほうがよい。
+
+## `mikuproject-skills` 側の想定ユースケース
+
+- current state を `ProjectModel` に戻す
+- `Daily SVG` / `Weekly SVG` / `Monthly Calendar SVG` を生成する
+- daily / weekly は SVG 文字列として返す
+- monthly は月別 SVG entries として返す
+
+## 補足
+
+- この相談は `Mermaid` ではなく SVG ファイル取得を対象にしている
+- `WBS XLSX` と同じく、派生表示 API の一部として整理したい

--- a/docs/upstream-wbs-xlsx-api-proposal.md
+++ b/docs/upstream-wbs-xlsx-api-proposal.md
@@ -1,0 +1,103 @@
+# Proposal for `mikuproject`: `WBS XLSX` core API
+
+この文書は、`mikuproject-skills` から見た
+`mikuproject` upstream への相談メモです。
+
+## 背景
+
+`mikuproject-skills` では Phase C として、
+report / presentation outputs を skill から扱いたい。
+
+最初の候補は `WBS XLSX` である。
+
+## 現状確認できている実装資産
+
+### workbook-level export
+
+- `src/ts/wbs-xlsx.ts`
+  - `__mikuprojectWbsXlsx.exportWbsWorkbook`
+  - `__mikuprojectWbsXlsx.collectWbsHolidayDates`
+
+### binary encode
+
+- `src/ts/excel-io.ts`
+  - `__mikuprojectExcelIo.XlsxWorkbookCodec`
+
+### UI 側導線
+
+- `src/ts/main.ts`
+  - `exportCurrentWbsXlsx`
+  - `buildCurrentWbsOptions(model)`
+
+## 相談したいこと
+
+`WBS XLSX` export についても、
+`mikuproject-skills` から扱いやすい `core API` 入口を追加できないか相談したい。
+
+## 相談理由
+
+### 1. Phase B と同様に upstream API を入口にしたい
+
+`mikuproject-skills` 側では、可能な限り `mikuproject` の `core API` を呼ぶ方針にしたい。
+
+`WBS XLSX` だけ low-level global を直接触る形にすると、
+skill 側で実装責務が増える。
+
+### 2. `WBS XLSX` は low-level option の意味づけが強い
+
+`holidayDates` や表示期間 option など、
+UI と表示仕様に関係する option がある。
+
+これを `mikuproject-skills` 側で勝手に再解釈するより、
+upstream 側で公開面を定義してもらうほうが自然である。
+
+### 3. 後続の `Markdown` / `SVG` / `Mermaid` と並べやすくしたい
+
+Phase C は `WBS XLSX` だけで終わらず、
+後続で `Markdown` / `SVG` / `Mermaid` に広がる見込みがある。
+
+その最初として、`WBS XLSX` の core API 化は意味がある。
+
+## 提案したい方向性
+
+API 名は例であり、確定ではない。
+
+```ts
+globalThis.__mikuprojectCoreApi.report = {
+  wbsXlsx: {
+    collectHolidayDates(model),
+    exportWorkbook(model, options),
+    encodeWorkbook(workbook)
+  }
+};
+```
+
+あるいは、より単純に:
+
+```ts
+globalThis.__mikuprojectCoreApi.wbsXlsx = {
+  collectHolidayDates(model),
+  exportWorkbook(model, options),
+  encodeWorkbook(workbook)
+};
+```
+
+## 最小提案
+
+最小構成としては、まず次でもよい。
+
+- `wbsXlsx.exportWorkbook(model, options)`
+- `wbsXlsx.encodeWorkbook(workbook)`
+
+これだけでも、`mikuproject-skills` 側は `WBS XLSX` export を組みやすくなる。
+
+## `mikuproject-skills` 側の想定ユースケース
+
+- current state を `ProjectModel` に戻す
+- `WBS XLSX` を生成する
+- `.xlsx` bytes として利用者に返す
+
+## 補足
+
+- この相談は report / presentation output としての `WBS XLSX` を対象にしている
+- 構造忠実 workbook `XLSX` とは別物として扱う


### PR DESCRIPTION
## 概要

Phase C の report / presentation output に関する設計メモと、`mikuproject` upstream 向けの API 提案書を追加します。あわせて、関連ドキュメントへの導線と TODO の設計メモを更新します。

## 変更内容

### 追加した詳細仕様メモ

- `WBS XLSX` の export workflow メモを追加
- `SVG` 系出力の詳細仕様メモを追加
- `Markdown / Mermaid` 出力の詳細仕様メモを追加

### 追加した upstream 相談メモ

- Phase C report output 全体の `core API` 提案メモを追加
- `WBS XLSX` 向け `core API` 提案メモを追加
- `SVG` 向け `core API` 提案メモを追加
- `Markdown / Mermaid` 向け `core API` 提案メモを追加

### 既存ドキュメントの更新

- `docs/development.md` に Phase C 詳細メモと upstream 相談メモへのリンクを追加
- `TODO.md` に設計メモ作成状況を追記

## 追加ファイル

- `docs/phase-c-wbs-xlsx-workflow.md`
- `docs/phase-c-svg-workflow.md`
- `docs/phase-c-markdown-mermaid-workflow.md`
- `docs/upstream-phase-c-report-api-proposal.md`
- `docs/upstream-wbs-xlsx-api-proposal.md`
- `docs/upstream-svg-api-proposal.md`
- `docs/upstream-markdown-mermaid-api-proposal.md`

## 補足

- 本コミットでは、確認できる範囲ではドキュメント追加・更新が中心です。