### PR TITLE
mikuproject スキル導入手順を追加し、Phase C レポート出力の定義と smoke test を拡張

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 coverage/
+.DS_Store
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@
 ## 文書の場所
 
 - 設計メモ: [agent-skill-design.md](./agent-skill-design.md)
+- skill 配置手順: [skill-installation.md](./skill-installation.md)
 - upstream 調査: [upstream-survey.md](./upstream-survey.md)
 - 次フェーズ案: [phase-b-primary-file-workflow.md](./phase-b-primary-file-workflow.md)
 - Phase B 詳細: [phase-b-msproject-xml-workflow.md](./phase-b-msproject-xml-workflow.md)

--- a/docs/skill-installation.md
+++ b/docs/skill-installation.md
@@ -1,0 +1,170 @@
+# Mikuproject Skill Installation
+
+この文書は、`skills/mikuproject` を開発中のリポジトリ配置から、Codex が利用可能な skill として認識する配置へ持っていく手順を整理したものです。
+
+## 先に結論
+
+- このリポジトリ内の開発用配置: `skills/mikuproject`
+- Codex の利用可能 skill 配置先: `$CODEX_HOME/skills/mikuproject`
+- `skills/` だけのコピーでは不足しやすい
+- 最短手順は、この `mikuproject-skills` リポジトリ全体を workspace に置いて開くこと
+- `.codex/skills` と workspace 側 `vendor/` は役割が違う
+
+このセッションでは `CODEX_HOME` 環境変数は未設定でした。
+ただし、組み込み skill の実体が `/Users/igapyon/.codex/skills/.system/...` にあるため、実運用上の候補は `/Users/igapyon/.codex/skills/mikuproject` です。
+
+## 前提
+
+- 開発元の skill は [`skills/mikuproject`](../skills/mikuproject) にある
+- `mikuproject` skill は [`vendor/mikuproject`](../vendor/mikuproject) にある upstream 実装や文書も参照する
+- 利用可能 skill の自動検出は、リポジトリ内の `skills/` をそのまま見るとは限らない
+- `.github/` は、この環境では skill の正規配置先として確認できていない
+
+## 配置の考え方
+
+Codex での skill 利用は、次の2層で考えます。
+
+- `.codex/skills/mikuproject`
+  Codex に skill を認識させるための配置
+- `<workspace>/vendor/mikuproject`
+  skill 実行時に参照される upstream 実装と文書の配置
+
+これは用途が違います。
+`skills` を `.codex` 配下へコピーしても、`vendor/mikuproject` が workspace 側に無ければ、`spec` や import/export 系で不足する可能性があります。
+
+## 推奨配置
+
+最も安全なのは、リポジトリ全体を workspace に置く形です。
+
+```text
+<workspace>/mikuproject-skills/
+  skills/
+    mikuproject/
+  vendor/
+    mikuproject/
+```
+
+そのうえで、必要なら skill を Codex 用に次へも配置します。
+
+```text
+~/.codex/
+  skills/
+    mikuproject/
+```
+
+## 最低限の構成
+
+workspace に最低限必要なのは次です。
+
+```text
+<workspace>/
+  vendor/
+    mikuproject/
+```
+
+Codex 側の認識用には次が必要です。
+
+```text
+~/.codex/
+  skills/
+    mikuproject/
+```
+
+つまり、次のように分担します。
+
+- `.codex/skills/mikuproject`
+  登録用
+- `<workspace>/vendor/mikuproject`
+  実行時参照用
+
+## 手順
+
+1. まず workspace を揃える
+
+推奨:
+
+- `mikuproject-skills` リポジトリ全体を workspace に置いて開く
+
+最低限必要:
+
+- `skills/mikuproject`
+- `vendor/mikuproject`
+
+`skills/` だけをコピーした構成では、`spec` や import/export 系の処理で参照先が欠ける可能性があります。
+
+2. 依存関係を入れる
+
+```bash
+npm install
+```
+
+3. リポジトリのテストを通す
+
+```bash
+npm test
+```
+
+4. 配置先ディレクトリを確認する
+
+`CODEX_HOME` が設定されているなら、その配下の `skills/` を使います。
+
+```bash
+printf '%s\n' "$CODEX_HOME"
+```
+
+5. `CODEX_HOME` が未設定なら、実体候補を確認する
+
+この環境では `/Users/igapyon/.codex` が候補です。
+したがって配置先候補は次です。
+
+```text
+/Users/igapyon/.codex/skills/mikuproject
+```
+
+6. `skills/mikuproject` を配置先へコピーまたは同期する
+
+例:
+
+```bash
+mkdir -p /Users/igapyon/.codex/skills
+cp -R skills/mikuproject /Users/igapyon/.codex/skills/mikuproject
+```
+
+既に配置済みで更新だけしたいなら、上書きコピーではなく同期方法を決めて運用します。
+
+7. Codex 側で skill 一覧に出ることを確認する
+
+この会話のように `Available skills` に `mikuproject` が出れば、登録済み skill として扱われます。
+
+## 運用上の整理
+
+- `skills/mikuproject`
+  このリポジトリで編集・レビュー・テストする開発元
+- `$CODEX_HOME/skills/mikuproject`
+  Codex に認識させるための利用側配置
+- `vendor/mikuproject`
+  skill が参照する upstream 実装と canonical 文書
+
+この2つは役割が違います。
+「repo にあること」と「このセッションで利用可能 skill として認識されること」は別です。
+さらに、`skills/` だけを別 workspace に持っていっても、参照先の `vendor/mikuproject` が無ければ不完全です。
+また、`vendor/mikuproject` は通常 `.codex` 配下ではなく、skill を使う workspace 側に置く前提で考えます。
+
+## 利用フロー
+
+skill が利用可能になったら、MVP の基本フローは次です。
+
+1. `spec` で `mikuproject-ai-json-spec` を取得する
+2. その spec を AI に渡して `project_draft_view` を生成させる
+3. `draft` で `project_draft_view` を取り込み、`mikuproject_workbook_json` にする
+4. `workbook` で現在の workbook state を次の AI へ渡す
+5. AI から `Patch JSON` を受け取る
+6. `patch` で既存 workbook state に反映する
+7. 更新後の `mikuproject_workbook_json` を次ターンへ持ち回る
+
+## 注意
+
+- `Patch JSON` は単独では適用できない
+- base state として既存の `mikuproject_workbook_json` が必要
+- この skill は `mikuproject` のブラウザ UI を置き換えるものではない
+- MVP では会話境界の state は `mikuproject_workbook_json` を使う

--- a/skills/mikuproject/SKILL.md
+++ b/skills/mikuproject/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mikuproject
-description: Work with mikuproject AI JSON workflows and primary file import/export workflows. Use when Codex needs to provide the mikuproject AI JSON spec, accept `project_draft_view`, apply `Patch JSON`, hand off `mikuproject_workbook_json`, or move between the current state and `MS Project XML` or structural workbook `XLSX`.
+description: Work with mikuproject AI JSON workflows, primary file import/export workflows, and Phase C report outputs. Use when Codex needs to provide the mikuproject AI JSON spec, accept `project_draft_view`, apply `Patch JSON`, hand off `mikuproject_workbook_json`, move between the current state and `MS Project XML` or structural workbook `XLSX`, or export `WBS XLSX` / `SVG` / `WBS Markdown` / `Mermaid`.
 ---
 
 # Mikuproject
@@ -10,7 +10,7 @@ Keep the focus on structured exchange and primary file workflows, not on replaci
 
 ## Core Workflow
 
-Treat the skill as one workflow with two layers of operations.
+Treat the skill as one workflow with three layers of operations.
 
 Phase A:
 
@@ -29,6 +29,15 @@ Phase B:
 - `workbook-import`: accept `mikuproject_workbook_json` as a replace import
 - `workbook-merge-import`: apply `mikuproject_workbook_json` onto an existing state
 - `workbook-export`: return current `mikuproject_workbook_json` as a file-oriented export
+
+Phase C:
+
+- `wbs-xlsx-export`: return current `WBS XLSX`
+- `daily-svg-export`: return current daily `SVG`
+- `weekly-svg-export`: return current weekly `SVG`
+- `monthly-calendar-svg-export`: return current monthly calendar `SVG` entries
+- `wbs-markdown-export`: return current `WBS Markdown`
+- `mermaid-export`: return current Mermaid gantt text
 
 At the conversation boundary, prefer `mikuproject_workbook_json` as the state exchange format.
 When processing input, convert through upstream APIs as needed.
@@ -61,6 +70,13 @@ Use these functions first:
 - `xlsx.importAsProjectModel()`
 - `xlsx.importIntoProjectModel()`
 - `patchJson.applyToProjectModel()`
+- `report.wbsXlsx.exportWorkbook()`
+- `report.wbsXlsx.exportBytes()`
+- `report.svg.exportDaily()`
+- `report.svg.exportWeekly()`
+- `report.svg.exportMonthlyCalendar()`
+- `report.wbsMarkdown.export()`
+- `report.mermaid.exportGantt()`
 
 If you need the exact upstream file map or supporting design notes, read [references/upstream-map.md](references/upstream-map.md).
 
@@ -153,6 +169,41 @@ Use this response shape:
 
 Do not add extra review comments unless the user asks for review.
 
+### Phase C report exports
+
+Require a current project state before running any report export.
+If the current state is `mikuproject_workbook_json`, rebuild a `ProjectModel` first.
+Prefer the unified `report` entrypoints on `__mikuprojectCoreApi`.
+
+Supported operations:
+
+- `wbs-xlsx-export`: use `report.wbsXlsx.exportBytes()` for file export, or `report.wbsXlsx.exportWorkbook()` when workbook-level inspection is needed
+- `daily-svg-export`: use `report.svg.exportDaily()`
+- `weekly-svg-export`: use `report.svg.exportWeekly()`
+- `monthly-calendar-svg-export`: use `report.svg.exportMonthlyCalendar()`
+- `wbs-markdown-export`: use `report.wbsMarkdown.export()`
+- `mermaid-export`: use `report.mermaid.exportGantt()`
+
+Use this processing order:
+
+1. require the current state
+2. convert `mikuproject_workbook_json` into a base `ProjectModel` when needed
+3. choose the matching `report.*` export entrypoint
+4. run the export with minimal options unless the user asked for specific export controls
+5. return the generated artifact or text with one short explanation
+
+Use this response shape:
+
+- one short line saying which report export this is
+- option summary, only when relevant
+- the generated artifact, text, or entry list
+
+For Phase C outputs, keep the distinction clear:
+
+- `WBS XLSX` is a report export and is not the same as structural workbook `XLSX`
+- `Mermaid` should be returned as gantt text, not necessarily fenced Markdown, unless the user asks for fencing
+- monthly calendar `SVG` may return multiple entries rather than a single file
+
 ## Error Handling
 
 Treat these as hard errors:
@@ -169,6 +220,8 @@ Treat these as soft errors:
 - workbook JSON contains unknown sheets or columns
 - unsupported workbook `XLSX` edits are ignored
 - merge imports apply only partial changes
+- some report export options may be rounded to upstream defaults
+- report outputs may simplify information compared with the full interactive UI
 
 On soft errors, continue and report the warnings clearly.
 

--- a/tests/mikuproject-core-api-smoke.test.js
+++ b/tests/mikuproject-core-api-smoke.test.js
@@ -3,57 +3,30 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadMikuprojectCoreApi } from "../vendor/mikuproject/scripts/lib/core-api-loader.mjs";
 
 const ROOT = process.cwd();
-
-function readVendored(relativePath) {
-  return readFileSync(path.resolve(ROOT, "vendor/mikuproject", relativePath), "utf8");
-}
-
-const typesCode = readVendored("src/js/types.js");
-const aiJsonUtilCode = readVendored("src/js/ai-json-util.js");
-const aiJsonSpecCode = readVendored("src/js/ai-json-spec.js");
-const msProjectXmlCode = readVendored("src/js/msproject-xml.js");
-const projectWorkbookSchemaCode = readVendored("src/js/project-workbook-schema.js");
-const excelIoCode = readVendored("src/js/excel-io.js");
-const projectXlsxCode = readVendored("src/js/project-xlsx.js");
-const projectWorkbookJsonCode = readVendored("src/js/project-workbook-json.js");
-const projectPatchJsonCode = readVendored("src/js/project-patch-json.js");
-const coreApiCode = readVendored("src/js/core-api.js");
-const dependencyXml = readVendored("testdata/dependency.xml");
+const dependencyXml = readFileSync(path.resolve(ROOT, "vendor/mikuproject/testdata/dependency.xml"), "utf8");
 
 function bootModules() {
-  new Function([
-    typesCode,
-    aiJsonUtilCode,
-    aiJsonSpecCode,
-    msProjectXmlCode,
-    projectWorkbookSchemaCode,
-    excelIoCode,
-    projectXlsxCode,
-    projectWorkbookJsonCode,
-    projectPatchJsonCode,
-    coreApiCode
-  ].join("\n"))();
-  return globalThis.__mikuprojectCoreApi;
+  return loadMikuprojectCoreApi({
+    rootDir: path.resolve(ROOT, "vendor/mikuproject")
+  });
 }
 
 describe("mikuproject core api smoke", () => {
-  beforeEach(() => {
-    delete globalThis.__mikuprojectAiJsonUtil;
-    delete globalThis.__mikuprojectAiJsonSpec;
-    delete globalThis.__mikuprojectXml;
-    delete globalThis.__mikuprojectProjectWorkbookSchema;
-    delete globalThis.__mikuprojectExcelIo;
-    delete globalThis.__mikuprojectProjectXlsx;
-    delete globalThis.__mikuprojectProjectWorkbookJson;
-    delete globalThis.__mikuprojectProjectPatchJson;
-    delete globalThis.__mikuprojectCoreApi;
+  let loaded = null;
+
+  afterEach(() => {
+    loaded?.dispose();
+    loaded = null;
   });
 
-  it("supports spec, draft, patch, workbook, and xlsx flows", () => {
-    const api = bootModules();
+  it("supports spec, draft, patch, workbook, xlsx, and report flows", () => {
+    loaded = bootModules();
+    const { api } = loaded;
 
     const spec = api.getAiJsonSpec();
     expect(spec.id).toBe("mikuproject-ai-json-spec");
@@ -124,5 +97,25 @@ describe("mikuproject core api smoke", () => {
     expect(xlsxMerge.kind).toBe("xlsx");
     expect(xlsxMerge.mode).toBe("merge");
     expect(Array.isArray(xlsxMerge.changes)).toBe(true);
+
+    const wbsWorkbook = api.report.wbsXlsx.exportWorkbook(baseModel, {
+      displayDaysBeforeBaseDate: 1,
+      displayDaysAfterBaseDate: 2
+    });
+    const wbsBytes = api.report.wbsXlsx.exportBytes(baseModel);
+    const dailySvg = api.report.svg.exportDaily(baseModel, { labelMode: "list" });
+    const weeklySvg = api.report.svg.exportWeekly(baseModel);
+    const monthlyCalendar = api.report.svg.exportMonthlyCalendar(baseModel);
+    const wbsMarkdown = api.report.wbsMarkdown.export(baseModel);
+    const mermaidText = api.report.mermaid.exportGantt(baseModel);
+
+    expect(wbsWorkbook.sheets.length).toBeGreaterThan(0);
+    expect(wbsBytes).toBeInstanceOf(Uint8Array);
+    expect(dailySvg).toContain("<svg");
+    expect(weeklySvg).toContain("<svg");
+    expect(monthlyCalendar.entries.length).toBeGreaterThan(0);
+    expect(monthlyCalendar.zipBytes).toBeInstanceOf(Uint8Array);
+    expect(wbsMarkdown).toContain("# WBS テーブル");
+    expect(mermaidText).toContain("gantt");
   });
 });

--- a/tests/mikuproject-phase-b-smoke.test.js
+++ b/tests/mikuproject-phase-b-smoke.test.js
@@ -3,57 +3,30 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadMikuprojectCoreApi } from "../vendor/mikuproject/scripts/lib/core-api-loader.mjs";
 
 const ROOT = process.cwd();
-
-function readVendored(relativePath) {
-  return readFileSync(path.resolve(ROOT, "vendor/mikuproject", relativePath), "utf8");
-}
-
-const typesCode = readVendored("src/js/types.js");
-const aiJsonUtilCode = readVendored("src/js/ai-json-util.js");
-const aiJsonSpecCode = readVendored("src/js/ai-json-spec.js");
-const msProjectXmlCode = readVendored("src/js/msproject-xml.js");
-const projectWorkbookSchemaCode = readVendored("src/js/project-workbook-schema.js");
-const excelIoCode = readVendored("src/js/excel-io.js");
-const projectXlsxCode = readVendored("src/js/project-xlsx.js");
-const projectWorkbookJsonCode = readVendored("src/js/project-workbook-json.js");
-const projectPatchJsonCode = readVendored("src/js/project-patch-json.js");
-const coreApiCode = readVendored("src/js/core-api.js");
-const dependencyXml = readVendored("testdata/dependency.xml");
+const dependencyXml = readFileSync(path.resolve(ROOT, "vendor/mikuproject/testdata/dependency.xml"), "utf8");
 
 function bootModules() {
-  new Function([
-    typesCode,
-    aiJsonUtilCode,
-    aiJsonSpecCode,
-    msProjectXmlCode,
-    projectWorkbookSchemaCode,
-    excelIoCode,
-    projectXlsxCode,
-    projectWorkbookJsonCode,
-    projectPatchJsonCode,
-    coreApiCode
-  ].join("\n"))();
-  return globalThis.__mikuprojectCoreApi;
+  return loadMikuprojectCoreApi({
+    rootDir: path.resolve(ROOT, "vendor/mikuproject")
+  });
 }
 
 describe("mikuproject phase b smoke", () => {
-  beforeEach(() => {
-    delete globalThis.__mikuprojectAiJsonUtil;
-    delete globalThis.__mikuprojectAiJsonSpec;
-    delete globalThis.__mikuprojectXml;
-    delete globalThis.__mikuprojectProjectWorkbookSchema;
-    delete globalThis.__mikuprojectExcelIo;
-    delete globalThis.__mikuprojectProjectXlsx;
-    delete globalThis.__mikuprojectProjectWorkbookJson;
-    delete globalThis.__mikuprojectProjectPatchJson;
-    delete globalThis.__mikuprojectCoreApi;
+  let loaded = null;
+
+  afterEach(() => {
+    loaded?.dispose();
+    loaded = null;
   });
 
   it("supports xml import/export, workbook import/export, and xlsx import/export", () => {
-    const api = bootModules();
+    loaded = bootModules();
+    const { api } = loaded;
 
     const xmlImportedModel = api.msProject.importFromXml(dependencyXml);
     const xmlImportedWorkbook = api.workbookJson.exportDocument(xmlImportedModel);


### PR DESCRIPTION
## 概要

この PR では、`mikuproject` スキルの導入手順を文書化するとともに、スキル定義を Phase C のレポート出力まで拡張し、関連する smoke test を更新しています。

## 変更内容

- `docs/skill-installation.md` を追加
  - リポジトリ内の `skills/mikuproject`、Codex 用の `$CODEX_HOME/skills/mikuproject`、workspace 側の `vendor/mikuproject` の役割分担を整理
  - `skills/` だけのコピーでは不足しうることを明記
  - MVP の利用フローと配置手順を追加
- `docs/development.md` を更新
  - `skill-installation.md` へのリンクを追加
- `skills/mikuproject/SKILL.md` を更新
  - スキル説明を Phase C のレポート出力まで拡張
  - ワークフローの層構成を 2 層から 3 層へ更新
  - 以下の Phase C 操作を追加
    - `wbs-xlsx-export`
    - `daily-svg-export`
    - `weekly-svg-export`
    - `monthly-calendar-svg-export`
    - `wbs-markdown-export`
    - `mermaid-export`
  - `report.*` 系 API の利用方針、処理順、返却形、注意点を追記
  - レポート出力に関する soft error の扱いを追記
- smoke test を更新
  - 手動の module bootstrapping をやめ、`loadMikuprojectCoreApi(...)` を利用する形に変更
  - 後始末を `dispose()` ベースに変更
  - core API smoke test の対象を report export まで拡張
    - WBS XLSX
    - daily SVG
    - weekly SVG
    - monthly calendar SVG
    - WBS Markdown
    - Mermaid gantt
- `.gitignore` を更新
  - `.DS_Store` を追加

## テスト

- 変更対象:
  - `tests/mikuproject-core-api-smoke.test.js`
  - `tests/mikuproject-phase-b-smoke.test.js`