### PR TITLE
handoff 型の位置づけを明確化し、CLI runner 前提の自動連携メモを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This MVP covers four operations:
 At the conversation boundary, the MVP passes state around as
 `mikuproject_workbook_json`.
 It does not try to replace the `mikuproject` browser UI.
+It also does not yet automate agent-to-agent execution between this skill
+and another model; the current MVP is a handoff-style workflow.
 
 The repository also now documents a Phase B primary file workflow for
 `MS Project XML`, structural workbook `XLSX`, and `mikuproject_workbook_json`.
@@ -64,6 +66,8 @@ Developer-oriented documents are available under [`docs/`](./docs/):
 
 会話境界では、MVP は state を `mikuproject_workbook_json` として持ち回ります。
 `mikuproject` のブラウザ UI を置き換えることは目指しません。
+また、現時点の MVP は handoff 型であり、この skill と別の生成AIのあいだを
+自動的に agent-to-agent 連携するところまでは扱いません。
 
 あわせて、このリポジトリでは `MS Project XML`、構造忠実 workbook `XLSX`、
 `mikuproject_workbook_json` を扱う Phase B の primary file workflow も整理しています。
@@ -86,6 +90,7 @@ Notes:
 
 - This skill does not replace the `mikuproject` browser UI.
 - For the MVP, state is passed around as `mikuproject_workbook_json` at the conversation boundary.
+- The current MVP returns handoff text on screen rather than automatically sending it to another model.
 
 ---
 
@@ -103,3 +108,4 @@ Notes:
 
 - この skill は `mikuproject` のブラウザ UI を置き換えるものではありません。
 - MVP では、会話境界の state は `mikuproject_workbook_json` として扱います。
+- 現在の MVP は handoff 型であり、`spec` や workbook の返却内容が画面に表示されます。

--- a/docs/agent-skill-design.md
+++ b/docs/agent-skill-design.md
@@ -173,6 +173,130 @@ Skill は次のように振る舞う。
 利用者が document kind を明示しなくても、中身から判定する。
 判定不能ならエラーにする。
 
+## handoff 型と agent-to-agent 型
+
+MVP の現在設計は handoff 型である。
+
+これは、skill が `spec` や `mikuproject_workbook_json` を画面に返し、
+その返却内容を利用者または上位エージェントが次の生成AIへ渡す形を意味する。
+
+たとえば `spec` では、skill 自身が外部の生成AIと自動対話するのではなく、
+次の AI ターンへ渡すための `mikuproject-ai-json-spec` を返す。
+
+したがって、`spec` 実行時に spec 本文や handoff 用プロンプトが画面に表示されるのは、
+MVP の想定どおりの挙動である。
+
+一方で、将来の理想形としては agent-to-agent 型もありうる。
+
+これは、skill の返却内容を画面にそのまま見せるのではなく、
+オーケストレータまたは上位エージェントが内部的に次の生成AI呼び出しへ接続する方式である。
+
+整理すると次の違いがある。
+
+- handoff 型
+  - `spec` や `workbook` を画面に返す
+  - 人手または上位エージェントが次の AI に渡す
+  - MVP の現行設計
+- agent-to-agent 型
+  - skill 出力を内部的に次の AI 呼び出しへ渡す
+  - 画面には中間 spec や handoff 文を必ずしも出さない
+  - skill 単体ではなく、実行基盤またはオーケストレーション設計が必要
+
+MVP では後者までは扱わない。
+まずは構造化 I/O と state 持ち回りを安定させることを優先する。
+
+## agent-to-agent 型へ進める場合の拡張方針
+
+将来 agent-to-agent 型へ進める場合は、skill 本体だけで完結させるより、
+上位の実行基盤またはオーケストレータで吸収する方が整合的である。
+
+理由:
+
+- 現在の skill は構造化 I/O と format 変換に責務を絞っている
+- 外部生成AIの呼び出しを skill 自体に埋め込むと、モデル依存や認証、失敗時制御まで抱え込む
+- `spec` / `draft` / `patch` / `workbook` の境界が崩れやすい
+
+### 推奨アーキテクチャ
+
+役割は次のように分ける。
+
+- `mikuproject` skill
+  - `spec` を返す
+  - `project_draft_view` を `mikuproject_workbook_json` に変換する
+  - `Patch JSON` を base state に適用する
+  - workbook / xml / xlsx / report を入出力する
+- オーケストレータ
+  - 利用者要求を受ける
+  - `spec` の返却内容を次の生成AIに内部連携する
+  - 返ってきた `project_draft_view` や `Patch JSON` を再度 skill に渡す
+  - 途中状態として `mikuproject_workbook_json` を保持する
+- 別の生成AI
+  - `project_draft_view` を生成する
+  - `Patch JSON` を生成する
+
+### 最小の内部連携シーケンス
+
+新規草案では次の流れを想定する。
+
+1. 利用者が要件を入力する
+2. オーケストレータが `mikuproject` skill の `spec` を呼ぶ
+3. オーケストレータが `spec` と利用者要件を別の生成AIへ渡す
+4. 生成AI が `project_draft_view` を返す
+5. オーケストレータがその結果を skill の `draft` に渡す
+6. skill が `mikuproject_workbook_json` を返す
+7. オーケストレータがその workbook state を次ターン用 state として保持する
+
+既存 WBS の修正では次の流れを想定する。
+
+1. オーケストレータが現在の `mikuproject_workbook_json` を保持している
+2. オーケストレータが workbook と変更要求を別の生成AIへ渡す
+3. 生成AI が `Patch JSON` を返す
+4. オーケストレータがその結果を skill の `patch` に渡す
+5. skill が更新後の `mikuproject_workbook_json` を返す
+6. オーケストレータが更新後 state を保持する
+
+### 必要な基盤機能
+
+agent-to-agent 型にするには、少なくとも次の基盤機能が必要になる。
+
+- skill 呼び出し結果を画面表示せず次段へ内部連携する制御
+- どの返却値を次の生成AIへ渡すかを決めるルーティング
+- `mikuproject_workbook_json` の会話境界 state 保存
+- 失敗時の再試行または中断制御
+- 生成AI の応答 kind 判定失敗時に `draft` / `patch` / `workbook` のどこへ戻すかの制御
+
+### 画面表示を抑えるための考え方
+
+`spec` の本文や handoff 文を画面にそのまま出したくない場合、
+skill 側で spec を返さなくするのではなく、
+オーケストレータ側で「中間出力」として扱うのが自然である。
+
+つまり:
+
+- skill の返却は維持する
+- その返却を UI へ出すか、次段の AI に回すかを基盤側で決める
+
+この方が handoff 型と agent-to-agent 型の両方を同じ skill 定義で支えやすい。
+
+### 非推奨の進め方
+
+次の方向は、現時点では非推奨とする。
+
+- `spec` operation の中で直接外部生成AIを呼ぶ
+- skill の責務として API key 管理やモデル選択を持たせる
+- `draft` / `patch` の kind 判定と外部 LLM 再呼び出しを一体化する
+
+これらは skill の責務を広げすぎ、再利用性と可観測性を落としやすい。
+
+### 将来の追加候補
+
+将来拡張としては次が考えられる。
+
+- `spec` の返却を `display` 用と `handoff` 用に分けるメタデータ
+- `draft` / `patch` の処理結果に次の推奨 action を添える
+- orchestrated run 用のサンプルフロー文書
+- 中間 state を workbook JSON で保存する runner 実装
+
 ## エラー方針
 
 ### hard error
@@ -198,6 +322,79 @@ MVP では次は人手または別会話に委ねる。
 - `mikuproject` ブラウザ UI 上での目視確認
 - WBS 内容の業務妥当性判断
 - SVG / XLSX / Markdown の出力活用
+
+## やさしい説明
+
+ここまでの話を、難しい言葉を使わずに言い換える。
+
+### 今の動き
+
+今の `mikuproject` skill は、次のように動く。
+
+1. `spec` を実行する
+2. skill が「次の AI に渡すための説明文」を返す
+3. その説明文が画面に表示される
+4. その先は、人が別の AI に渡す
+
+つまり今は、
+「skill が別の AI と自動で会話する」のではなく、
+「skill が次に渡す文章を出す」方式である。
+
+### いま困っている点
+
+あなたが気にしているのはここである。
+
+- `spec` の結果が画面に見えてしまう
+- 本当は、その結果を画面に出さずに、次の AI に自動で渡してほしい
+
+これは自然な要望である。
+ただし、今の MVP はそこまでは作っていない。
+
+### 何が足りないか
+
+足りないのは `mikuproject` skill 本体ではなく、
+「skill の結果を受け取って、次の AI に自動で渡す仕組み」である。
+
+この文書ではそれをオーケストレータと呼んでいたが、
+ここでは単に「つなぎ役」と呼ぶ。
+
+### つなぎ役がやること
+
+つなぎ役は、次の順で動く。
+
+1. 利用者の依頼を受ける
+2. `mikuproject` skill から `spec` を受け取る
+3. その内容を画面に出さず、次の AI に渡す
+4. 次の AI から返ってきた `project_draft_view` や `Patch JSON` を受け取る
+5. それをまた `mikuproject` skill に渡す
+6. 更新後の workbook state を保持する
+
+### つまり何を作ればよいか
+
+次に必要なのは、`mikuproject` skill の大改造ではない。
+まず必要なのは次の仕組みである。
+
+- skill の返り値を画面表示せず受け取る
+- その返り値を別の AI にそのまま渡す
+- 返ってきた JSON をもう一度 skill に戻す
+- `mikuproject_workbook_json` を途中状態として持ち回る
+
+### 先に決めるべきこと
+
+実装前に決めるべき点は少ない。
+
+1. どの AI に `spec` や workbook を渡すか
+2. 中間の返り値を画面に見せるか見せないか
+3. workbook state をどこに保持するか
+
+### いまの結論
+
+結論は次のとおり。
+
+- 今の挙動は不具合ではない
+- ただし、理想形には足りない
+- 足りないのは skill よりも「つなぎ役」
+- 次に進めるなら、その「つなぎ役」の要件を書き出すのがよい
 
 ## MVP 以外
 

--- a/docs/agent-to-agent-runner.md
+++ b/docs/agent-to-agent-runner.md
@@ -1,0 +1,254 @@
+# CLI Runner Notes
+
+この文書は、`mikuproject` skill の返り値を別の生成AIへ自動で渡す
+CLI runner に必要な最小要件を整理したものです。
+
+ここでは難しい設計用語は避け、まず何を入れて何を返し、
+途中で何を持てばよいか、どんなコマンドにするかだけを書く。
+
+## 採用方針
+
+最初の自動連携は CLI runner として作る。
+
+理由:
+
+- 挙動を固定しやすい
+- どこで失敗したか切り分けやすい
+- テストしやすい
+- 中間出力を画面に出すかどうかを制御しやすい
+
+## 目的
+
+次をできるようにする。
+
+- `spec` の結果を画面にそのまま表示せず、別の生成AIへ渡す
+- 返ってきた `project_draft_view` を `mikuproject` skill に戻す
+- 返ってきた `Patch JSON` を `mikuproject` skill に戻す
+- 途中状態を `mikuproject_workbook_json` として持ち回る
+
+## この仕組みが受け取るもの
+
+- 利用者の依頼文
+- 現在の `mikuproject_workbook_json`
+  - 新規作成のときは無くてもよい
+- どの操作をしたいか
+  - 新規草案
+  - 既存 WBS の修正
+  - workbook の確認
+
+## この仕組みが返すもの
+
+- 新規草案なら、生成された `mikuproject_workbook_json`
+- 修正なら、更新後の `mikuproject_workbook_json`
+- 必要に応じて、途中で返ってきた warning
+- 必要に応じて、最終出力
+  - Mermaid
+  - WBS Markdown
+  - SVG
+  - XLSX
+
+## 保持する状態
+
+最低限、次の 1 つを持てばよい。
+
+- 現在の `mikuproject_workbook_json`
+
+最初の実装では、state はファイルとして保存する前提にする。
+
+理由:
+
+- CLI と相性がよい
+- 途中経過を確認しやすい
+- セッションをまたいで再利用しやすい
+
+候補:
+
+- `state/current-workbook.json`
+
+理由:
+
+- `draft` の結果を次ターンへ持ち回れる
+- `patch` の base state として使える
+- 必要なら report export にも使える
+
+## 最小フロー 1: 新規草案
+
+1. 利用者が要件を書く
+2. つなぎ役が `mikuproject` skill に `spec` を要求する
+3. つなぎ役が `spec` 本文を別の生成AIへ渡す
+4. 別の生成AIが `project_draft_view` を返す
+5. つなぎ役がその JSON を `mikuproject` skill の `draft` に渡す
+6. `mikuproject` skill が `mikuproject_workbook_json` を返す
+7. つなぎ役がその workbook を現在状態として保存する
+
+## 最小フロー 2: 既存 WBS の修正
+
+1. つなぎ役は現在の `mikuproject_workbook_json` を持っている
+2. 利用者が変更内容を書く
+3. つなぎ役が workbook と変更内容を別の生成AIへ渡す
+4. 別の生成AIが `Patch JSON` を返す
+5. つなぎ役がその JSON を `mikuproject` skill の `patch` に渡す
+6. `mikuproject` skill が更新後の `mikuproject_workbook_json` を返す
+7. つなぎ役が更新後 workbook を保存する
+
+## 最小フロー 3: 出力だけ欲しいとき
+
+1. つなぎ役は現在の `mikuproject_workbook_json` を持っている
+2. 利用者が出力形式を指定する
+3. つなぎ役が `mikuproject` skill に export 操作を要求する
+4. skill が Mermaid / Markdown / SVG / XLSX を返す
+5. つなぎ役がそれを最終結果として表示する
+
+## 最初の CLI コマンド案
+
+最初は次の 3 つでよい。
+
+### 1. 草案作成
+
+役割:
+
+- 要件文から `project_draft_view` を生成させる
+- それを workbook state に変換して保存する
+
+入れるもの:
+
+- 要件文ファイル、または要件文文字列
+
+返すもの:
+
+- 保存後の `mikuproject_workbook_json`
+- warning の要約
+
+コマンド名候補:
+
+- `npm run runner:draft`
+- `node scripts/mikuproject-runner.mjs draft`
+
+### 2. 変更反映
+
+役割:
+
+- 現在の workbook state と変更要求から `Patch JSON` を生成させる
+- patch を適用して state を更新する
+
+入れるもの:
+
+- 変更要求文
+- 現在の workbook state
+
+返すもの:
+
+- 更新後の `mikuproject_workbook_json`
+- change summary
+- warning の要約
+
+コマンド名候補:
+
+- `npm run runner:patch`
+- `node scripts/mikuproject-runner.mjs patch`
+
+### 3. 出力
+
+役割:
+
+- 現在の workbook state から最終出力を作る
+
+入れるもの:
+
+- 出力種別
+  - `mermaid`
+  - `wbs-markdown`
+  - `daily-svg`
+  - `weekly-svg`
+  - `monthly-calendar-svg`
+  - `wbs-xlsx`
+
+返すもの:
+
+- 指定した形式の出力
+
+コマンド名候補:
+
+- `npm run runner:export`
+- `node scripts/mikuproject-runner.mjs export mermaid`
+
+## 画面に出さないもの
+
+CLI runner では、次は通常表示しない方がよい。
+
+- `spec` 本文
+- handoff 用補助文
+- 途中の `project_draft_view`
+- 途中の `Patch JSON`
+
+必要なら `--debug` 時だけ表示する。
+
+## 画面に出すもの
+
+理想形では、次は中間表示しない。
+
+- `spec` 本文
+- handoff 用の補助文
+- 中間の workbook JSON
+
+代わりに、画面には次だけを出す。
+
+- 処理中であること
+- 失敗時の理由
+- 最終結果
+- 必要なら warning の要約
+
+## 失敗したときの扱い
+
+最低限、次を分けて扱う。
+
+- `project_draft_view` が返らなかった
+- `Patch JSON` が返らなかった
+- kind 判定に失敗した
+- `patch` に必要な base state が無い
+- `mikuproject` skill 側で warning または error が返った
+
+## 最初の実装を小さく保つための条件
+
+最初は次だけでよい。
+
+- 新規草案
+- 既存修正
+- workbook state の保持
+
+最初から不要なもの:
+
+- 複数 AI の比較
+- 自動再試行の複雑な制御
+- UI 上の細かい可視化
+- 高度なローカル編集フロー
+
+## 実装前の確認事項
+
+CLI 採用を前提にすると、実装前に確認したいのは次の 3 点で足りる。
+
+1. 別の生成AIへ渡す呼び出し口を何にするか
+2. `mikuproject_workbook_json` をどの state ファイルに保存するか
+3. 中間出力を完全非表示にするか、デバッグ時だけ見せるか
+
+## 初期実装の形
+
+最初は 1 ファイルの CLI でよい。
+
+候補:
+
+- `scripts/mikuproject-runner.mjs`
+
+役割:
+
+- 引数を読む
+- state ファイルを読む
+- `mikuproject` 側の API を呼ぶ
+- 別の生成AIを呼ぶ
+- 結果を state ファイルへ保存する
+- 最終結果だけ表示する
+
+## 結論
+
+`mikuproject` skill 自体は、すでに structured I/O の役割をかなり持っている。
+次に必要なのは、その前後をつないで自動で往復させる小さな CLI 実行役である。

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@
 ## 文書の場所
 
 - 設計メモ: [agent-skill-design.md](./agent-skill-design.md)
+- 自動連携メモ: [agent-to-agent-runner.md](./agent-to-agent-runner.md)
 - skill 配置手順: [skill-installation.md](./skill-installation.md)
 - upstream 調査: [upstream-survey.md](./upstream-survey.md)
 - 次フェーズ案: [phase-b-primary-file-workflow.md](./phase-b-primary-file-workflow.md)


### PR DESCRIPTION
## 概要

この PR では、`mikuproject` skill の MVP が handoff 型であることを README と設計メモに明記し、将来的な agent-to-agent 自動連携に向けた整理として、CLI runner 前提のメモを追加しています。

## 変更内容

- `README.md` を更新
  - 現在の MVP は handoff 型であることを追記
  - `spec` や workbook の返却内容が画面に表示される挙動が、現行設計どおりであることを補足
  - 別モデルへの自動 agent-to-agent 連携は現時点では未対応であることを明記
- `docs/agent-skill-design.md` を更新
  - handoff 型と agent-to-agent 型の違いを整理
  - agent-to-agent 型へ進める場合の拡張方針を追加
  - 推奨アーキテクチャ、最小シーケンス、必要な基盤機能、非推奨の進め方を追記
  - 難しい用語を避けた「やさしい説明」を追加
- `docs/agent-to-agent-runner.md` を追加
  - CLI runner を採用方針とするメモを新規追加
  - runner の目的、入出力、保持する state、最小フローを整理
  - 最初の CLI コマンド案、画面表示方針、失敗時の扱い、初期実装の形を整理
- `docs/development.md` を更新
  - `agent-to-agent-runner.md` へのリンクを追加

## 期待する効果

- 現在の `mikuproject` skill の責務と限界が読み取りやすくなる
- `spec` の結果が画面に表示される理由を README と設計文書の両方で説明できる
- 将来的な自動連携の検討を、CLI runner を前提に進めやすくなる