### PR TITLE
agent-internal 前提の利用導線を強化し、bundled upstream と `devel` 取り込みを整備

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,13 +31,13 @@
 取得:
 
 ```bash
-git fetch https://github.com/igapyon/mikuproject.git main
+git fetch https://github.com/igapyon/mikuproject.git devel
 ```
 
 同期:
 
 ```bash
-git subtree pull --prefix=vendor/mikuproject https://github.com/igapyon/mikuproject.git main
+git subtree pull --prefix=vendor/mikuproject https://github.com/igapyon/mikuproject.git devel
 ```
 
 ## テスト

--- a/docs/participant-invite-ja.md
+++ b/docs/participant-invite-ja.md
@@ -22,8 +22,9 @@
 <skill-home>/
   skills/
     mikuproject/
-  vendor/
-    mikuproject/
+      _bundled/
+        vendor/
+          mikuproject/
 ```
 
 ## いま試せること

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,8 +61,9 @@ npm run build:bundle
 bundle/skill-bundle/
   skills/
     mikuproject/
-  vendor/
-    mikuproject/
+      _bundled/
+        vendor/
+          mikuproject/
 ```
 
 その中身を skill home にコピーします。
@@ -104,7 +105,30 @@ npm run build
 
 ## まず試す流れ
 
-### 1. spec を出す
+### 1. まずはそのまま WBS 作成を依頼する
+
+会話では、まず通常の依頼文で始めます。
+
+```text
+れでえいやあでWBSつくって
+```
+
+期待すること:
+
+- エージェントが内部で `spec` を参照する
+- エージェントが内部で `project_draft_view` を作る
+- それを `mikuproject` に内部で取り込み、workbook state まで進める
+- ユーザーには WBS 要約や完成結果だけが返る
+
+避けたい挙動:
+
+- `spec` 本文がそのまま画面に出る
+- `project_draft_view` の JSON がそのまま画面に出る
+- `以下を mikuproject に渡せます` のような visible handoff で止まる
+
+このような表示が出る場合は、fallback 動作になっている可能性があります。
+
+### 2. 明示的に spec を見たい場合だけ出す
 
 会話で次のように依頼します。
 
@@ -115,18 +139,11 @@ spec を出して
 期待すること:
 
 - `mikuproject-ai-json-spec` が返る
-- 実行環境が agent-internal execution に対応していれば、これは内部保持される
-- 対応していない場合だけ fallback として画面に表示される
+- これは通常運用ではなく、raw spec を確認したいときの操作
 
-### 2. draft を作る
+### 3. すでにある `project_draft_view` を取り込む
 
-要件を与えて、`project_draft_view` を作らせます。
-
-```text
-次の要件で project_draft_view を作って
-```
-
-返ってきた `project_draft_view` を使って、次のように依頼します。
+外部で作った `project_draft_view` を取り込むときは、次のように依頼します。
 
 ```text
 この project_draft_view を取り込んで
@@ -136,15 +153,21 @@ spec を出して
 
 - `mikuproject_workbook_json` が返る
 
-### 3. patch を当てる
+### 4. patch を当てる
 
-現在の workbook state をもとに変更したいときは、変更要求を与えて `Patch JSON` を作らせます。
+現在の workbook state をもとに変更したいときは、通常は変更要求をそのまま伝えます。
 
 ```text
-この workbook をもとに Patch JSON を作って
+このWBSを1週間短くして
 ```
 
-返ってきた `Patch JSON` を使って、次のように依頼します。
+期待すること:
+
+- エージェントが内部で `Patch JSON` を作る
+- それを `mikuproject` に内部で適用する
+- ユーザーには更新後の内容だけを返す
+
+外部で作った `Patch JSON` を適用するときは、次のように依頼します。
 
 ```text
 この Patch JSON を反映して
@@ -154,7 +177,7 @@ spec を出して
 
 - 更新後の `mikuproject_workbook_json` が返る
 
-### 4. workbook を引き渡す
+### 5. workbook を引き渡す
 
 現在の state をもう一度 AI に渡したいときは、次のように依頼します。
 

--- a/docs/skill-installation.md
+++ b/docs/skill-installation.md
@@ -1,220 +1,185 @@
 # Mikuproject Skill Installation
 
-この文書は、`skills/mikuproject` を開発中のリポジトリ配置から、Codex が利用可能な skill として認識する配置へ持っていく手順を整理したものです。
+この文書は、配布された `skill-bundle.zip` をインストール先の環境で使えるようにする手順です。
+
+開発元リポジトリでの build 手順ではなく、受け取った bundle をどう配置するかに絞って説明します。
+
+## 対象
+
+この手順は、次のような人向けです。
+
+- `skill-bundle.zip` を受け取った
+- インストール先の環境で `mikuproject` skill を使いたい
+- 配布元リポジトリの `npm run build` は実行しない
+
+## 配布物
+
+受け取る想定の配布物は次です。
+
+- `skill-bundle.zip`
+
+展開すると、次のような構成になります。
+
+```text
+skill-bundle/
+  skills/
+    mikuproject/
+      _bundled/
+        vendor/
+          mikuproject/
+  README.md
+```
 
 ## 先に結論
 
-- このリポジトリ内の開発用配置: `skills/mikuproject`
-- Codex の利用可能 skill 配置先: `$CODEX_HOME/skills/mikuproject`
-- 配布用には `bundle/skill-bundle` を生成できる
-- `skills/` だけのコピーでは不足しやすい
-- 最短手順は、この `mikuproject-skills` リポジトリ全体を workspace に置いて開くこと
-- `.codex/skills` と workspace 側 `vendor/` は役割が違う
+やることは単純です。
 
-このセッションでは `CODEX_HOME` 環境変数は未設定でした。
-ただし、組み込み skill の実体が `/Users/igapyon/.codex/skills/.system/...` にあるため、実運用上の候補は `/Users/igapyon/.codex/skills/mikuproject` です。
+1. `skill-bundle.zip` を展開する
+2. 展開してできた `skill-bundle/` の中身を skill home の直下へコピーする
+3. 実行環境を再起動または再読込する
+4. 利用可能 skill 一覧に `mikuproject` が出ることを確認する
 
-## 前提
-
-- 開発元の skill は [`skills/mikuproject`](../skills/mikuproject) にある
-- `mikuproject` skill は [`vendor/mikuproject`](../vendor/mikuproject) にある upstream 実装や文書も参照する
-- 利用可能 skill の自動検出は、リポジトリ内の `skills/` をそのまま見るとは限らない
-- `.github/` は、この環境では skill の正規配置先として確認できていない
-
-## 配置の考え方
-
-Codex での skill 利用は、次の2層で考えます。
-
-- `.codex/skills/mikuproject`
-  Codex に skill を認識させるための配置
-- `<workspace>/vendor/mikuproject`
-  skill 実行時に参照される upstream 実装と文書の配置
-
-これは用途が違います。
-`skills` を `.codex` 配下へコピーしても、`vendor/mikuproject` が workspace 側に無ければ、`spec` や import/export 系で不足する可能性があります。
-
-## 推奨配置
-
-最も安全なのは、リポジトリ全体を workspace に置く形です。
+コピー後の想定構成は次です。
 
 ```text
-<workspace>/mikuproject-skills/
+<skill-home>/
   skills/
     mikuproject/
-  vendor/
-    mikuproject/
+      _bundled/
+        vendor/
+          mikuproject/
 ```
-
-そのうえで、必要なら skill を Codex 用に次へも配置します。
-
-```text
-~/.codex/
-  skills/
-    mikuproject/
-```
-
-## 最低限の構成
-
-workspace に最低限必要なのは次です。
-
-```text
-<workspace>/
-  vendor/
-    mikuproject/
-```
-
-Codex 側の認識用には次が必要です。
-
-```text
-~/.codex/
-  skills/
-    mikuproject/
-```
-
-つまり、次のように分担します。
-
-- `.codex/skills/mikuproject`
-  登録用
-- `<workspace>/vendor/mikuproject`
-  実行時参照用
 
 ## 手順
 
-1. まず workspace を揃える
+### 1. `skill-bundle.zip` を展開する
 
-推奨:
+まず、受け取った `skill-bundle.zip` を任意の作業用フォルダに展開します。
 
-- `mikuproject-skills` リポジトリ全体を workspace に置いて開く
+展開後は `skill-bundle/` ディレクトリが見えるはずです。
 
-最低限必要:
+### 2. skill home を確認する
+
+`mikuproject` skill は、bundle 版では `skills/mikuproject` の中に必要な upstream 実装を同梱しています。
+
+必要なのは次です。
 
 - `skills/mikuproject`
-- `vendor/mikuproject`
+- `skills/mikuproject/_bundled/vendor/mikuproject`
 
-`skills/` だけをコピーした構成では、`spec` や import/export 系の処理で参照先が欠ける可能性があります。
-
-2. 依存関係を入れる
-
-```bash
-npm install
-```
-
-3. リポジトリのテストを通す
-
-```bash
-npm test
-```
-
-4. 配布までまとめて実行するなら `build` を使う
-
-```bash
-npm run build
-```
-
-これで次が順に実行されます。
-
-- `npm test`
-- `npm run build:bundle`
-- `npm run build:bundle:zip`
-
-5. 配布用 bundle を個別に作る
-
-```bash
-npm run build:bundle
-```
-
-生成先:
+最終的な構成は次です。
 
 ```text
-bundle/skill-bundle/
+<skill-home>/
   skills/
     mikuproject/
-  vendor/
+      _bundled/
+        vendor/
+          mikuproject/
+```
+
+この文書では、この `<skill-home>` をインストール先の配置ルートと呼びます。
+
+### 3. `skill-bundle/` の中身を skill home へコピーする
+
+展開した `skill-bundle/` の中身を、そのまま skill home 直下へコピーします。
+
+重要なのは次です。
+
+- `skill-bundle/skills/mikuproject` を `<skill-home>/skills/mikuproject` に入れる
+- `skills/mikuproject` 配下の `_bundled/vendor/mikuproject` も一緒に入ることを保つ
+
+この bundle では、`skill-bundle/` の中身をそのまま `<skill-home>/` へコピーすれば足ります。
+
+### 4. 実行環境を再起動または再読込する
+
+skill 一覧は起動時に読まれることがあります。
+
+そのため、コピー後は次のどちらかを行います。
+
+- 実行環境を再起動する
+- skill 一覧を再読込できる場合は再読込する
+
+### 5. `mikuproject` が利用可能 skill に出ることを確認する
+
+利用可能 skill 一覧に `mikuproject` が出れば、インストール自体は完了です。
+
+ここで `mikuproject` が出ない場合は、まず次を確認します。
+
+- コピー先が skill home 直下になっているか
+- `skills/mikuproject/_bundled/vendor/mikuproject` があるか
+- 実行環境を再起動または再読込したか
+
+## よくある間違い
+
+### `skills/mikuproject` の一部だけをコピーする
+
+これは不足です。
+
+`mikuproject` skill は bundled upstream も参照します。
+`skills/mikuproject` の中身を欠いた状態では、`spec` や import/export 系で不足する可能性があります。
+
+### `_bundled/vendor/mikuproject` を落としてしまう
+
+これは不足です。
+
+今回の bundle 配布では、`vendor/mikuproject` は `skills/mikuproject/_bundled/vendor/mikuproject` に同梱されています。
+この bundled 部分を落とすと、実装本体が見つからず fallback に落ちる可能性があります。
+
+### `skill-bundle/` ディレクトリごと入れてしまう
+
+必要なのは `skill-bundle/` そのものではなく、その中身です。
+
+正しい配置:
+
+```text
+<skill-home>/
+  skills/
     mikuproject/
+      _bundled/
+        vendor/
+          mikuproject/
 ```
 
-この bundle は `.codex` 配下へそのまま展開できる first cut です。
-
-zip 配布物も必要なら、次を使えます。
-
-```bash
-npm run build:bundle:zip
-```
-
-生成先:
+避けたい配置:
 
 ```text
-bundle/skill-bundle.zip
+<skill-home>/
+  skill-bundle/
+    skills/
 ```
 
-6. 配置先ディレクトリを確認する
+## インストール後の最初の試し方
 
-`CODEX_HOME` が設定されているなら、その配下の `skills/` を使います。
-
-```bash
-printf '%s\n' "$CODEX_HOME"
-```
-
-7. `CODEX_HOME` が未設定なら、実体候補を確認する
-
-この環境では `/Users/igapyon/.codex` が候補です。
-したがって配置先候補は次です。
-
-```text
-/Users/igapyon/.codex/skills/mikuproject
-```
-
-8. `bundle/skill-bundle` の中身を skill home 配下へコピーする
+インストールできたら、まずは通常の依頼文で試します。
 
 例:
 
-```bash
-cp -R bundle/skill-bundle/. "$CODEX_HOME"/
-```
-
-これで次の構成になります。
-
 ```text
-.codex/
-  skills/
-    mikuproject/
-  vendor/
-    mikuproject/
+れでえいやあでWBSつくって
 ```
 
-9. Codex 側で skill 一覧に出ることを確認する
+望ましい動作は次です。
 
-この会話のように `Available skills` に `mikuproject` が出れば、登録済み skill として扱われます。
+- エージェントが内部で `mikuproject` を使う
+- 中間の `spec` や `project_draft_view` をそのまま画面に出さない
+- WBS 要約や結果だけを返す
 
-## 運用上の整理
+ただし実行環境によっては fallback があり、次が画面に出ることがあります。
 
-- `skills/mikuproject`
-  このリポジトリで編集・レビュー・テストする開発元
-- `$CODEX_HOME/skills/mikuproject`
-  Codex に認識させるための利用側配置
-- `vendor/mikuproject`
-  skill が参照する upstream 実装と canonical 文書
+- `spec`
+- `project_draft_view`
+- `Patch JSON`
+- `mikuproject_workbook_json`
 
-この2つは役割が違います。
-「repo にあること」と「このセッションで利用可能 skill として認識されること」は別です。
-さらに、`skills/` だけを別 workspace に持っていっても、参照先の `vendor/mikuproject` が無ければ不完全です。
-また、`vendor/mikuproject` は通常 `.codex` 配下ではなく、skill を使う workspace 側に置く前提で考えます。
+その場合でもインストール失敗とは限りません。
+まずは `mikuproject` が認識されているかと、処理自体が進むかを確認してください。
 
-## 利用フロー
+## まだ未対応のもの
 
-skill が利用可能になったら、MVP の基本フローは次です。
+- `report` 系 CLI
 
-1. `spec` で `mikuproject-ai-json-spec` を取得する
-2. その spec を AI に渡して `project_draft_view` を生成させる
-3. `draft` で `project_draft_view` を取り込み、`mikuproject_workbook_json` にする
-4. `workbook` で現在の workbook state を次の AI へ渡す
-5. AI から `Patch JSON` を受け取る
-6. `patch` で既存 workbook state に反映する
-7. 更新後の `mikuproject_workbook_json` を次ターンへ持ち回る
+## 関連文書
 
-## 注意
-
-- `Patch JSON` は単独では適用できない
-- base state として既存の `mikuproject_workbook_json` が必要
-- この skill は `mikuproject` のブラウザ UI を置き換えるものではない
-- MVP では会話境界の state は `mikuproject_workbook_json` を使う
+- 使い始め: [quickstart.md](./quickstart.md)
+- 設計メモ: [agent-skill-design.md](./agent-skill-design.md)

--- a/scripts/build-skill-bundle.mjs
+++ b/scripts/build-skill-bundle.mjs
@@ -10,7 +10,10 @@ const repoRoot = path.resolve(__dirname, "..");
 
 const bundleRoot = path.resolve(repoRoot, "bundle/skill-bundle");
 const bundleSkillsRoot = path.resolve(bundleRoot, "skills");
-const bundleVendorRoot = path.resolve(bundleRoot, "vendor");
+const bundledVendorRoot = path.resolve(
+  bundleRoot,
+  "skills/mikuproject/_bundled/vendor"
+);
 const sourceSkillRoot = path.resolve(repoRoot, "skills/mikuproject");
 const sourceVendorRoot = path.resolve(repoRoot, "vendor/mikuproject");
 
@@ -22,12 +25,12 @@ function main() {
 
   fs.rmSync(bundleRoot, { recursive: true, force: true });
   fs.mkdirSync(bundleSkillsRoot, { recursive: true });
-  fs.mkdirSync(bundleVendorRoot, { recursive: true });
+  fs.mkdirSync(bundledVendorRoot, { recursive: true });
 
   fs.cpSync(sourceSkillRoot, path.resolve(bundleSkillsRoot, "mikuproject"), {
     recursive: true
   });
-  fs.cpSync(sourceVendorRoot, path.resolve(bundleVendorRoot, "mikuproject"), {
+  fs.cpSync(sourceVendorRoot, path.resolve(bundledVendorRoot, "mikuproject"), {
     recursive: true
   });
 
@@ -38,7 +41,7 @@ function main() {
     "[build:bundle] copy this directory's contents under your skill home root",
     "[build:bundle] included:",
     "  - skills/mikuproject",
-    "  - vendor/mikuproject"
+    "  - skills/mikuproject/_bundled/vendor/mikuproject"
   ].join("\n"));
   process.stdout.write("\n");
 }
@@ -59,7 +62,7 @@ function writeReadme() {
     "## What This Bundle Contains",
     "",
     "- `skills/mikuproject`",
-    "- `vendor/mikuproject`",
+    "- `skills/mikuproject/_bundled/vendor/mikuproject`",
     "",
     "Copy these contents under your skill home root so that the final layout becomes:",
     "",
@@ -67,16 +70,17 @@ function writeReadme() {
     "<skill-home>/",
     "  skills/",
     "    mikuproject/",
-    "  vendor/",
-    "    mikuproject/",
+    "      _bundled/",
+    "        vendor/",
+    "          mikuproject/",
     "```",
     "",
     "## What You Can Do Now",
     "",
-    "- Ask for `spec`",
-    "- Import `project_draft_view`",
-    "- Apply `Patch JSON`",
-    "- Hand off `mikuproject_workbook_json`",
+    "- Ask for a WBS directly and let the agent use `mikuproject` internally",
+    "- Import `project_draft_view` when you already have external JSON",
+    "- Apply `Patch JSON` when you already have external JSON",
+    "- Inspect or export workbook state when you explicitly need it",
     "- Use the bundled `mikuproject` CLI for:",
     "  - `ai spec`",
     "  - `state from-draft`",
@@ -87,13 +91,13 @@ function writeReadme() {
     "",
     "## Important Limitation",
     "",
-    "The preferred mode is agent-internal execution.",
+    "The intended mode is agent-internal execution.",
     "",
-    "That means the agent should keep intermediate artifacts off-screen when the host runtime supports it.",
+    "That means the agent should keep intermediate artifacts off-screen and should not stop at visible handoff JSON during normal WBS work.",
     "",
     "Fallback behavior:",
     "",
-    "- if the host runtime cannot keep intermediate state hidden, `spec` or workbook JSON may still appear on screen",
+    "- if the host runtime cannot keep intermediate state hidden, `spec`, `project_draft_view`, `Patch JSON`, or workbook JSON may still appear on screen",
     "- that fallback is usable, but it is not the preferred user experience",
     "",
     "So the target mode is agent-internal hidden workflow, with handoff-style display only as a fallback.",
@@ -107,7 +111,7 @@ function writeReadme() {
     "## Not Yet Included",
     "",
     "- `report` CLI commands",
-    "- fully hidden agent-internal execution",
+    "- guaranteed hidden execution in every host runtime",
     "",
     "## Quick Start",
     "",
@@ -115,7 +119,7 @@ function writeReadme() {
     "2. Restart or reopen your Codex environment if needed.",
     "3. Confirm that `mikuproject` appears in available skills.",
     "4. Start by asking:",
-    "   - `spec を出して`",
+    "   - `れでえいやあでWBSつくって`",
     "   - `この project_draft_view を取り込んで`",
     "   - `この Patch JSON を反映して`"
   ].join("\n");

--- a/skills/mikuproject/SKILL.md
+++ b/skills/mikuproject/SKILL.md
@@ -23,6 +23,34 @@ That fallback is allowed, but it is not the preferred user experience.
 
 Visible handoff text is therefore a compatibility path, not the main path.
 
+## Response Discipline
+
+When the user asks for a WBS, schedule draft, or plan revision, do the internal `mikuproject` steps yourself when possible.
+Do not stop at "here is something you can hand to mikuproject" if this skill is already active.
+
+Prefer this sequence:
+
+1. understand the user intent
+2. retrieve the spec internally when needed
+3. produce `project_draft_view` or `Patch JSON` internally
+4. import or apply it through `mikuproject`
+5. keep the resulting workbook state internal
+6. show the user only a short summary, or a final export they explicitly asked for
+
+Do not default to any of these behaviors:
+
+- showing `project_draft_view` just because you created it
+- showing `Patch JSON` just because you created it
+- saying "Below is ..." or "以下を mikuproject に渡せます" unless visible handoff is truly required
+- asking the user to manually pass generated JSON back into the same active skill flow
+
+If the skill is active and the host runtime can continue internally, complete the import/apply step before responding.
+Only expose intermediate JSON when one of these is true:
+
+- the user explicitly asks to inspect the raw JSON
+- the host runtime cannot continue without visible handoff
+- debugging the intermediate artifact is necessary to explain a failure
+
 ## Core Workflow
 
 Treat the skill as one workflow with three layers of operations.
@@ -102,6 +130,7 @@ If you need the exact upstream file map or supporting design notes, read [refere
 Get the spec from `getAiJsonSpecText()` or `getAiJsonSpec()` first.
 When the user explicitly asks to see the spec, return the full `mikuproject-ai-json-spec` text and, when useful, its version.
 Otherwise, prefer using it internally and continue the workflow without showing the full spec text.
+Do not answer a normal planning request by first printing the spec.
 
 When the user explicitly asks to see the spec, use this response shape:
 
@@ -136,6 +165,8 @@ Use this response shape:
 - the resulting `mikuproject_workbook_json`, only when the user explicitly wants the raw state
 
 If the user did not ask to see raw workbook JSON, prefer returning a short success summary and keep the workbook state internal.
+When the user asked for a WBS, do not stop after creating `project_draft_view`.
+Import it and continue to workbook state internally before responding.
 
 When the import succeeds, keep the explanation short.
 Do not add speculative schedule corrections or WBS advice unless the user asks for review.
@@ -166,6 +197,8 @@ Use this response shape:
 
 If no changes were applied, say so explicitly and still report any warnings.
 If the user did not ask to see raw workbook JSON, prefer returning a short success summary and keep the updated state internal.
+When the user asked to revise the existing plan, do not stop after generating `Patch JSON`.
+Apply it internally before responding.
 
 ### `workbook`
 
@@ -194,6 +227,8 @@ Use this response shape:
 
 Do not add extra review comments unless the user asks for review.
 Do not call this operation just to move state between internal steps when the host runtime can already keep the workbook state internally.
+Do not use this operation as a default response to normal planning requests.
+Use it only for explicit workbook inspection or real fallback handoff.
 
 ### Phase C report exports
 

--- a/skills/mikuproject/agents/openai.yaml
+++ b/skills/mikuproject/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "mikuproject"
   short_description: "AI JSON workflow for mikuproject WBS"
-  default_prompt: "Use $mikuproject to work with mikuproject AI JSON workflows for WBS drafting, workbook exchange, and patch application. Prefer agent-internal execution: keep spec, draft, patch, and workbook artifacts off-screen unless the user explicitly asks to see them."
+  default_prompt: "Use $mikuproject to work with mikuproject AI JSON workflows for WBS drafting, workbook exchange, and patch application. Prefer agent-internal execution: keep spec, draft, patch, and workbook artifacts off-screen unless the user explicitly asks to see them. When the user asks for a WBS or a revision, do not stop at visible handoff JSON. Generate the needed intermediate artifact internally, import or apply it through mikuproject, keep the resulting workbook state internal, and answer with a concise result summary or the final export the user requested. Only show raw spec, project_draft_view, Patch JSON, or workbook JSON when explicit inspection or fallback display is truly required."

--- a/vendor/mikuproject/.gitignore
+++ b/vendor/mikuproject/.gitignore
@@ -3,4 +3,4 @@ local-data
 node_modules/
 coverage/
 *.log
-
+bundle/

--- a/vendor/mikuproject/README.md
+++ b/vendor/mikuproject/README.md
@@ -116,7 +116,7 @@ npm run build
 npm test
 ```
 
-開発用コマンドの詳細、テスト運用、`local-data/` の扱いは [docs/development.md](docs/development.md) を参照してください。
+`npm run build` には `build:web`、`build:cli-bundle`、`test:fast` が含まれる。開発用コマンドの詳細、テスト運用、`local-data/` の扱いは [docs/development.md](docs/development.md) を参照してください。
 
 ## 再利用 API
 
@@ -193,6 +193,35 @@ mikuproject export xlsx --in workbook.json --out project.xlsx
 ```
 
 `report` 系の派生出力 CLI は次段候補として分離して扱う。
+
+## CLI bundle first cut
+
+`mikuproject` 側で CLI 実行に必要な runtime をまとめた自己完結ディレクトリ bundle を出力できるようにしている。
+
+```bash
+npm run build:cli-bundle
+```
+
+既定の出力先は `bundle/mikuproject-cli-bundle/` で、主に次を含む。
+
+```text
+bundle/
+  mikuproject-cli-bundle/
+    README.md
+    package.json
+    scripts/
+    src/
+    node_modules/
+```
+
+この bundle は追加の `npm install` なしで、そのまま CLI 実行に使える first cut を狙っている。たとえば次で動く。
+
+```bash
+node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs ai spec
+node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs export xml --in workbook.json --out project.xml
+```
+
+bundle 生成時は、repo root の `node_modules` にある `jsdom` とその runtime 依存を取り込む。そのため、bundle 生成前には一度 `npm install` 済みであることを前提とする。
 
 ## 関連ドキュメント
 

--- a/vendor/mikuproject/docs/architecture.md
+++ b/vendor/mikuproject/docs/architecture.md
@@ -167,16 +167,17 @@ sample 生成も含めた従来相当のフル実行:
 npm run build:full
 ```
 
-`npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
+`npm run build` は日常開発向けの標準 build で、`build:web`、`build:cli-bundle`、`test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web`、`build:cli-bundle`、`test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
 
 スクリプトの役割は次のとおり。
 
 - `npm run build:js`: `src/ts/` から `src/js/` を生成する
 - `npm run build:html`: `index-src.html` と `mikuproject-src.html` から `index.html` と `mikuproject.html` を生成する
 - `npm run build:web`: JavaScript 生成と HTML 生成をまとめて行う
+- `npm run build:cli-bundle`: 自己完結 CLI bundle を `bundle/mikuproject-cli-bundle/` へ生成する
 - `npm run build:xlsx-sample`: `local-data/` 配下へサンプル XLSX / Markdown を生成する
 - `npm run build:app`: `build:web` と `build:xlsx-sample` を順に実行する
-- `npm run build:full`: `build:web` と `test:full` を順に実行する
+- `npm run build:full`: `build:web`、`build:cli-bundle`、`test:full` を順に実行する
 - `npm run test:extended`: validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系 UI suite を実行する
 - `npm run test:all`: `fast + ui + extended` をすべて実行する
 

--- a/vendor/mikuproject/docs/development.md
+++ b/vendor/mikuproject/docs/development.md
@@ -13,9 +13,9 @@ npm run build
 npm test
 ```
 
-- `npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する
+- `npm run build` は日常開発向けの標準 build で、`build:web`、`build:cli-bundle`、`test:fast` を順に実行する
 - `npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する
-- `npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する
+- `npm run build:full` は `build:web`、`build:cli-bundle`、`test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する
 - `build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する
 
 ## テストの使い分け

--- a/vendor/mikuproject/package.json
+++ b/vendor/mikuproject/package.json
@@ -9,13 +9,14 @@
     "mikuproject": "scripts/mikuproject-cli.mjs"
   },
   "scripts": {
-    "build": "npm run build:web && npm run test:fast",
+    "build": "npm run build:web && npm run build:cli-bundle && npm run test:fast",
     "build:js": "node scripts/build-project.mjs --js-only",
     "build:html": "node scripts/build-project.mjs --html-only",
     "build:web": "node scripts/build-project.mjs",
+    "build:cli-bundle": "node scripts/build-cli-bundle.mjs",
     "build:app": "npm run build:web && npm run build:xlsx-sample",
     "cli": "node scripts/mikuproject-cli.mjs",
-    "build:full": "npm run build:web && npm run test:full",
+    "build:full": "npm run build:web && npm run build:cli-bundle && npm run test:full",
     "build:xlsx-sample": "node scripts/build-project-xlsx-sample.mjs",
     "test": "node scripts/run-tests.mjs all",
     "test:fast": "node scripts/run-tests.mjs fast",

--- a/vendor/mikuproject/scripts/build-cli-bundle.mjs
+++ b/vendor/mikuproject/scripts/build-cli-bundle.mjs
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+import { CORE_API_MODULE_RELATIVE_PATHS } from "./lib/core-api-loader.mjs";
+
+const ROOT = process.cwd();
+const requireFromRoot = createRequire(path.resolve(ROOT, "package.json"));
+
+const args = parseArgs(process.argv.slice(2));
+const outDir = path.resolve(
+  args.out || path.join(ROOT, "bundle", "mikuproject-cli-bundle")
+);
+const bundleName = path.basename(outDir);
+
+const rootPackageJson = readJson(path.resolve(ROOT, "package.json"));
+const jsdomPackageJsonPath = resolveInstalledPackageJson("jsdom", requireFromRoot);
+const jsdomPackageJson = readJson(jsdomPackageJsonPath);
+
+buildCliBundle();
+
+function buildCliBundle() {
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  for (const relativePath of getRuntimeFileRelativePaths()) {
+    copyRepoFile(relativePath);
+  }
+
+  writeBundlePackageJson();
+  writeBundleReadme();
+  copyRuntimeNodeModules();
+
+  console.log(`[build:cli-bundle] generated ${path.relative(ROOT, outDir)}`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`未対応の引数です: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`オプション ${token} には値が必要です`);
+    }
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function getRuntimeFileRelativePaths() {
+  const files = new Set([
+    "scripts/mikuproject-cli.mjs",
+    "scripts/lib/core-api-loader.mjs",
+    ...CORE_API_MODULE_RELATIVE_PATHS
+  ]);
+  return Array.from(files).sort();
+}
+
+function copyRepoFile(relativePath) {
+  const sourcePath = path.resolve(ROOT, relativePath);
+  const destinationPath = path.resolve(outDir, relativePath);
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
+function writeBundlePackageJson() {
+  const document = {
+    name: `${rootPackageJson.name}-cli-bundle`,
+    version: rootPackageJson.version,
+    private: true,
+    description: "Self-contained mikuproject CLI bundle.",
+    license: rootPackageJson.license,
+    type: "module",
+    bin: {
+      mikuproject: "scripts/mikuproject-cli.mjs"
+    },
+    engines: {
+      node: ">=18"
+    },
+    dependencies: {
+      jsdom: jsdomPackageJson.version
+    }
+  };
+
+  const packageJsonPath = path.resolve(outDir, "package.json");
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+}
+
+function writeBundleReadme() {
+  const readmePath = path.resolve(outDir, "README.md");
+  const lines = [
+    `# ${bundleName}`,
+    "",
+    "この bundle は `mikuproject` CLI を追加の `npm install` なしで実行するための配布物です。",
+    "",
+    "## 使い方",
+    "",
+    "```bash",
+    "node scripts/mikuproject-cli.mjs ai spec",
+    "```",
+    "",
+    "または `npm link` / `npm install -g <展開先>` 相当で `mikuproject` を PATH に出せます。"
+  ];
+  fs.writeFileSync(readmePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function copyRuntimeNodeModules() {
+  const destinationNodeModulesDir = path.resolve(outDir, "node_modules");
+  fs.mkdirSync(destinationNodeModulesDir, { recursive: true });
+
+  const visitedPackageJsonPaths = new Set();
+  const queue = [{ name: "jsdom", requireFn: requireFromRoot }];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const packageJsonPath = resolveInstalledPackageJson(current.name, current.requireFn);
+    if (visitedPackageJsonPaths.has(packageJsonPath)) {
+      continue;
+    }
+    visitedPackageJsonPaths.add(packageJsonPath);
+
+    const packageJson = readJson(packageJsonPath);
+    const packageDir = path.dirname(packageJsonPath);
+    const sourceNodeModulesDir = findOwningNodeModulesDir(packageDir);
+    const relativePackageDir = path.relative(sourceNodeModulesDir, packageDir);
+    if (relativePackageDir.startsWith("..")) {
+      throw new Error(`node_modules 配下でない package を検出しました: ${packageDir}`);
+    }
+
+    const destinationPackageDir = path.resolve(destinationNodeModulesDir, relativePackageDir);
+    fs.mkdirSync(path.dirname(destinationPackageDir), { recursive: true });
+    fs.cpSync(packageDir, destinationPackageDir, {
+      recursive: true,
+      force: true,
+      dereference: true
+    });
+
+    const packageRequire = createRequire(packageJsonPath);
+    for (const dependencyName of Object.keys(packageJson.dependencies || {})) {
+      queue.push({ name: dependencyName, requireFn: packageRequire });
+    }
+    for (const dependencyName of Object.keys(packageJson.optionalDependencies || {})) {
+      if (!isPackageInstalled(dependencyName, packageRequire)) {
+        continue;
+      }
+      queue.push({ name: dependencyName, requireFn: packageRequire });
+    }
+  }
+}
+
+function findOwningNodeModulesDir(packageDir) {
+  let currentDir = packageDir;
+  while (true) {
+    if (path.basename(currentDir) === "node_modules") {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`node_modules 配下でない package を検出しました: ${packageDir}`);
+    }
+    currentDir = parentDir;
+  }
+}
+
+function resolveInstalledPackageJson(packageName, requireFn) {
+  try {
+    return requireFn.resolve(`${packageName}/package.json`);
+  } catch (_error) {
+    try {
+      const resolvedEntryPath = requireFn.resolve(packageName);
+      return findNearestPackageJson(resolvedEntryPath, packageName);
+    } catch (_innerError) {
+      throw new Error(
+        `${packageName} が見つかりません。先に repo root で npm install を実行してください`
+      );
+    }
+  }
+}
+
+function isPackageInstalled(packageName, requireFn) {
+  try {
+    requireFn.resolve(`${packageName}/package.json`);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function findNearestPackageJson(startPath, expectedPackageName) {
+  let currentDir = path.dirname(startPath);
+  while (true) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      const document = readJson(packageJsonPath);
+      if (document.name === expectedPackageName) {
+        return packageJsonPath;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`package.json が見つかりません: ${expectedPackageName}`);
+    }
+    currentDir = parentDir;
+  }
+}

--- a/vendor/mikuproject/scripts/lib/core-api-loader.mjs
+++ b/vendor/mikuproject/scripts/lib/core-api-loader.mjs
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_ROOT_DIR = path.resolve(__dirname, "../..");
 
-const CORE_API_MODULE_RELATIVE_PATHS = [
+export const CORE_API_MODULE_RELATIVE_PATHS = [
   "src/js/types.js",
   "src/js/ai-json-util.js",
   "src/js/ai-json-spec.js",

--- a/vendor/mikuproject/tests/mikuproject-cli.test.js
+++ b/vendor/mikuproject/tests/mikuproject-cli.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const cliPath = path.resolve(repoRoot, "scripts/mikuproject-cli.mjs");
+const cliBundleBuildPath = path.resolve(repoRoot, "scripts/build-cli-bundle.mjs");
 
 const tempDirs = [];
 
@@ -111,6 +112,28 @@ describe("mikuproject cli", () => {
     expect(Buffer.isBuffer(result.stdout)).toBe(true);
     expect(result.stdout.subarray(0, 2).toString("utf8")).toBe("PK");
   });
+
+  it("builds a self-contained cli bundle that runs outside the repo", () => {
+    const bundleRoot = path.join(createTempDir("mikuproject-cli-bundle-test-"), "bundle");
+    const buildResult = spawnSync(process.execPath, [cliBundleBuildPath, "--out", bundleRoot], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+
+    expect(buildResult.status).toBe(0);
+    expect(existsSync(path.join(bundleRoot, "node_modules", "jsdom", "package.json"))).toBe(true);
+
+    const workbookPath = writeTempJson("bundle-workbook.json", buildWorkbookState("Bundled CLI export xml"));
+    const bundledCliPath = path.join(bundleRoot, "scripts", "mikuproject-cli.mjs");
+    const result = spawnSync(process.execPath, [bundledCliPath, "export", "xml", "--in", workbookPath], {
+      cwd: path.dirname(workbookPath),
+      encoding: "utf8"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<Project");
+    expect(result.stdout).toContain("<Name>Bundled CLI export xml</Name>");
+  });
 });
 
 function runCli(args, options = {}) {
@@ -121,11 +144,16 @@ function runCli(args, options = {}) {
 }
 
 function writeTempJson(fileName, documentLike) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "mikuproject-cli-test-"));
-  tempDirs.push(dir);
+  const dir = createTempDir("mikuproject-cli-test-");
   const filePath = path.join(dir, fileName);
   writeFileSync(filePath, `${JSON.stringify(documentLike, null, 2)}\n`, "utf8");
   return filePath;
+}
+
+function createTempDir(prefix) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
 }
 
 function buildWorkbookState(projectName) {


### PR DESCRIPTION
## 概要

この PR では、`mikuproject` skill の利用導線を agent-internal execution 前提に寄せるとともに、配布用 bundle を bundled upstream 同梱型に変更しています。あわせて、`vendor/mikuproject` の参照更新として `devel` 系の変更を取り込み、CLI bundle 関連の upstream 追加を反映しています。

## 変更内容

### 1. skill の応答方針を強化

- `skills/mikuproject/SKILL.md` を更新
  - `Response Discipline` を追加
  - WBS 作成や改訂依頼では、`project_draft_view` / `Patch JSON` の visible handoff で止まらず、可能なら内部で import / apply まで進める方針を明記
  - `spec` / `draft` / `patch` / `workbook` の各操作で、中間 JSON を既定表示しない方針を強化
- `skills/mikuproject/agents/openai.yaml` を更新
  - `default_prompt` に、visible handoff JSON で止まらず内部処理を優先する指示を追加

### 2. 利用者向け文書を agent-internal 前提に更新

- `docs/quickstart.md` を更新
  - `spec を出して` から始める流れではなく、通常の WBS 作成依頼から始める流れに変更
  - fallback 表示時に避けたい挙動を明記
  - 外部 `project_draft_view` / `Patch JSON` を取り込むケースを分けて整理
- `docs/skill-installation.md` を全面更新
  - 開発元リポジトリ前提ではなく、`skill-bundle.zip` を受け取ったインストール先での手順に書き換え
  - `skill-bundle/` の中身を skill home にコピーする手順に整理
  - bundled upstream を含む配置と、誤配置しやすい例を追記
- `docs/participant-invite-ja.md` を更新
  - 配布先の構成例を bundled upstream 前提に更新

### 3. 配布 bundle を自己完結寄りの構成へ変更

- `scripts/build-skill-bundle.mjs` を更新
  - 配布物内の upstream 配置を top-level `vendor/` ではなく `skills/mikuproject/_bundled/vendor/mikuproject` に変更
  - bundle 同梱 README も新構成と agent-internal 前提に合わせて更新
- この変更により、配布 bundle の構成は次の形になります

```text
skill-bundle/
  skills/
    mikuproject/
      _bundled/
        vendor/
          mikuproject/
```

### 4. upstream `mikuproject` の更新取り込み

- `docs/development.md` を更新
  - `git subtree` の取得先・同期先を `main` から `devel` に変更
- `vendor/mikuproject` を更新
  - `README.md`
  - `docs/architecture.md`
  - `docs/development.md`
  - `package.json`
  - `scripts/lib/core-api-loader.mjs`
  - `tests/mikuproject-cli.test.js`
- `vendor/mikuproject/scripts/build-cli-bundle.mjs` を追加
  - self-contained CLI bundle を生成する first cut を取り込み
- `vendor/mikuproject/package.json` を更新
  - `build` / `build:full` に `build:cli-bundle` を含む構成へ更新

## テスト

- `npm test`
- 実行結果: 27ファイル・221テスト成功