### PR TITLE
bundle 配布に `node_modules` を同梱し孤立環境での CLI 起動を回帰確認する

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -99,6 +99,11 @@
 - `tests/mikuproject-core-api-smoke.test.js` を追加した
 - `vendor/mikuproject/tests/**/*.test.js` も root から実行できるようにした
 - `npm test` で 24 files / 208 tests passed を確認した
+- 2026-04-14: bundle を repo 外の孤立ディレクトリへコピーして `mikuproject-cli.mjs --help` を実行すると `jsdom` 解決失敗で落ちる問題を確認した
+- 2026-04-14: `scripts/build-skill-bundle.mjs` を修正し、`skills/mikuproject/vendor/mikuproject/node_modules` に `jsdom` の runtime 依存一式を同梱するようにした
+- 2026-04-14: `tests/mikuproject-bundle-smoke.test.js` を追加し、bundle を一時ディレクトリへ展開した孤立環境でも CLI が起動することを回帰確認に入れた
+- 2026-04-14: `docs/skill-installation.md` に bundle の必須構成として `skills/mikuproject/vendor/mikuproject/node_modules` を追記した
+- 2026-04-14: `npm test` で 3 files / 3 tests passed を確認し、`npm run build:bundle:zip` で `bundle/mikuproject-skills-20260413.zip` を再生成した
 
 ## 10. 文書化
 

--- a/docs/skill-installation.md
+++ b/docs/skill-installation.md
@@ -7,6 +7,7 @@
 前提:
 
 - この skill の実行には Node.js が必要です
+- 配布 bundle には `mikuproject` CLI 実行用の runtime 依存も同梱されます
 
 ## 対象
 
@@ -29,6 +30,7 @@ skills/
   mikuproject/
     vendor/
       mikuproject/
+        node_modules/
 ```
 
 ## 先に結論
@@ -48,6 +50,7 @@ skills/
     mikuproject/
       vendor/
         mikuproject/
+          node_modules/
 ```
 
 ## 手順
@@ -67,6 +70,7 @@ skills/
 
 - `skills/mikuproject`
 - `skills/mikuproject/vendor/mikuproject`
+- `skills/mikuproject/vendor/mikuproject/node_modules`
 
 最終的な構成は次です。
 
@@ -76,6 +80,7 @@ skills/
     mikuproject/
       vendor/
         mikuproject/
+          node_modules/
 ```
 
 この文書では、この `<skill-home>` をインストール先の配置ルートと呼びます。
@@ -88,6 +93,7 @@ skills/
 
 - 展開した `skills/mikuproject` を `<skill-home>/skills/mikuproject` に入れる
 - `skills/mikuproject/vendor/mikuproject` も一緒に入ることを保つ
+- `skills/mikuproject/vendor/mikuproject/node_modules` も一緒に入ることを保つ
 
 この bundle では、展開した `skills/` をそのまま `<skill-home>/` へコピーすれば足ります。
 
@@ -108,6 +114,7 @@ skill 一覧は起動時に読まれることがあります。
 
 - コピー先が skill home 直下になっているか
 - `skills/mikuproject/vendor/mikuproject` があるか
+- `skills/mikuproject/vendor/mikuproject/node_modules` があるか
 - 実行環境を再起動または再読込したか
 
 ## よくある間違い
@@ -126,6 +133,14 @@ skill 一覧は起動時に読まれることがあります。
 今回の bundle 配布では、参照用 upstream は `skills/mikuproject/vendor/mikuproject` に同梱されています。
 この vendor 部分を落とすと、参照先の一貫性が崩れ、bundle 内の `skills/mikuproject` 単体で自己完結しません。
 
+### `node_modules` を落としてしまう
+
+これは不足です。
+
+bundle 版では `skills/mikuproject/vendor/mikuproject/node_modules` まで含めて、
+CLI 実行に必要な runtime 依存を自己完結させます。
+この部分を落とすと、配布先によっては `jsdom` などの解決に失敗します。
+
 ### 展開場所の `skills/` 以外までまとめて入れてしまう
 
 必要なのは展開された `skills/` です。
@@ -138,6 +153,7 @@ skill 一覧は起動時に読まれることがあります。
     mikuproject/
       vendor/
         mikuproject/
+          node_modules/
 ```
 
 ## インストール後の最初の試し方

--- a/scripts/build-skill-bundle.mjs
+++ b/scripts/build-skill-bundle.mjs
@@ -14,14 +14,19 @@ const bundledVendorRoot = path.resolve(
   bundleRoot,
   "skills/mikuproject/vendor/mikuproject"
 );
+const bundledVendorNodeModulesRoot = path.resolve(bundledVendorRoot, "node_modules");
 const sourceSkillRoot = path.resolve(repoRoot, "skills/mikuproject");
 const sourceVendorRoot = path.resolve(repoRoot, "vendor/mikuproject");
+const sourceNodeModulesRoot = path.resolve(repoRoot, "node_modules");
+const sourcePackageLockPath = path.resolve(repoRoot, "package-lock.json");
 
 main();
 
 function main() {
   ensureSourceExists(sourceSkillRoot, "skills/mikuproject");
   ensureSourceExists(sourceVendorRoot, "vendor/mikuproject");
+  ensureSourceExists(sourceNodeModulesRoot, "node_modules");
+  ensureSourceExists(sourcePackageLockPath, "package-lock.json");
 
   fs.rmSync(bundleRoot, { recursive: true, force: true });
   fs.mkdirSync(bundleSkillsRoot, { recursive: true });
@@ -32,13 +37,15 @@ function main() {
   fs.cpSync(sourceVendorRoot, bundledVendorRoot, {
     recursive: true
   });
+  copyRuntimeDependencies();
 
   process.stdout.write([
     "[build:bundle] generated bundle/mikuproject-skills",
     "[build:bundle] copy this directory's contents under your skill home root",
     "[build:bundle] included:",
     "  - skills/mikuproject",
-    "  - skills/mikuproject/vendor/mikuproject"
+    "  - skills/mikuproject/vendor/mikuproject",
+    "  - skills/mikuproject/vendor/mikuproject/node_modules (runtime only)"
   ].join("\n"));
   process.stdout.write("\n");
 }
@@ -47,4 +54,44 @@ function ensureSourceExists(targetPath, label) {
   if (!fs.existsSync(targetPath)) {
     throw new Error(`missing source directory: ${label}`);
   }
+}
+
+function copyRuntimeDependencies() {
+  const packageLock = JSON.parse(fs.readFileSync(sourcePackageLockPath, "utf8"));
+  const packages = packageLock.packages || {};
+  const requiredPackages = collectRequiredPackages(packages, ["jsdom"]);
+
+  fs.mkdirSync(bundledVendorNodeModulesRoot, { recursive: true });
+  for (const packageName of requiredPackages) {
+    const sourceDir = path.resolve(sourceNodeModulesRoot, packageName);
+    ensureSourceExists(sourceDir, `node_modules/${packageName}`);
+    fs.cpSync(sourceDir, path.resolve(bundledVendorNodeModulesRoot, packageName), {
+      recursive: true
+    });
+  }
+}
+
+function collectRequiredPackages(packages, roots) {
+  const pending = [...roots];
+  const required = new Set();
+
+  while (pending.length > 0) {
+    const packageName = pending.pop();
+    if (!packageName || required.has(packageName)) {
+      continue;
+    }
+
+    const packageKey = `node_modules/${packageName}`;
+    const packageInfo = packages[packageKey];
+    if (!packageInfo) {
+      throw new Error(`package-lock.json missing entry for ${packageKey}`);
+    }
+
+    required.add(packageName);
+    for (const dependencyName of Object.keys(packageInfo.dependencies || {})) {
+      pending.push(dependencyName);
+    }
+  }
+
+  return Array.from(required).sort((left, right) => left.localeCompare(right));
 }

--- a/tests/mikuproject-bundle-smoke.test.js
+++ b/tests/mikuproject-bundle-smoke.test.js
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const buildScriptPath = path.resolve(ROOT, "scripts/build-skill-bundle.mjs");
+const builtCliPath = path.resolve(
+  ROOT,
+  "bundle/mikuproject-skills/skills/mikuproject/vendor/mikuproject/scripts/mikuproject-cli.mjs"
+);
+
+describe("mikuproject bundle smoke", () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  it("runs the bundled CLI from an isolated install tree", () => {
+    execFileSync("node", [buildScriptPath], {
+      cwd: ROOT,
+      encoding: "utf8"
+    });
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mikuproject-bundle-test-"));
+    tempDirs.push(tempRoot);
+
+    const isolatedSkillRoot = path.resolve(tempRoot, "skills");
+    fs.cpSync(path.resolve(ROOT, "bundle/mikuproject-skills/skills"), isolatedSkillRoot, {
+      recursive: true
+    });
+
+    const isolatedCliPath = path.resolve(
+      isolatedSkillRoot,
+      "mikuproject/vendor/mikuproject/scripts/mikuproject-cli.mjs"
+    );
+    const output = execFileSync("node", [isolatedCliPath, "--help"], {
+      cwd: tempRoot,
+      encoding: "utf8"
+    });
+
+    expect(fs.existsSync(builtCliPath)).toBe(true);
+    expect(output).toContain("mikuproject report all");
+  });
+});


### PR DESCRIPTION
## 概要

bundle を repo 外の孤立ディレクトリへコピーして `mikuproject-cli.mjs --help` を実行した際に、`jsdom` の解決失敗で CLI が起動できない問題に対応します。

この変更では、bundle 作成時に `skills/mikuproject/vendor/mikuproject/node_modules` を同梱するようにし、あわせて孤立環境での CLI 起動を確認する smoke test とインストール手順の記載を追加しています。

## 変更内容

- `scripts/build-skill-bundle.mjs`
  - bundle 作成時に `node_modules` と `package-lock.json` の存在確認を追加
  - `package-lock.json` を参照して `jsdom` から必要な runtime 依存を収集し、`skills/mikuproject/vendor/mikuproject/node_modules` にコピーする処理を追加
  - bundle 出力内容のメッセージに runtime 依存の同梱を追記
- `tests/mikuproject-bundle-smoke.test.js`
  - bundle を一時ディレクトリへ展開した孤立環境で CLI の `--help` が実行できることを確認する smoke test を追加
- `docs/skill-installation.md`
  - 配布 bundle に runtime 依存が同梱されることを追記
  - インストール時に `skills/mikuproject/vendor/mikuproject/node_modules` も含めて配置する必要があることを明記
  - `node_modules` を落とした場合の注意事項を追加
- `TODO.md`
  - 本対応の確認内容と検証メモを追記

## 確認事項

- `npm test` で 3 files / 3 tests passed を確認
- `npm run build:bundle:zip` で bundle を再生成

## 影響範囲

- bundle 配布物の構成
- bundle 配布先での `mikuproject` CLI 実行
- bundle インストール手順の文書