### PR TITLE
Release publish 時にビルド済み ZIP を添付する GitHub Actions workflow を追加

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,46 @@
+name: Build And Upload Release Asset
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build release bundle
+        run: npm run build
+
+      - name: Locate release zip
+        id: locate_zip
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find bundle -maxdepth 1 -type f -name 'mikuproject-skills-*.zip' | head -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "release zip not found under bundle/" >&2
+            exit 1
+          fi
+          echo "zip_path=${zip_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload zip to GitHub Release
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.locate_zip.outputs.zip_path }}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

GitHub Release の `published` を契機にビルドを実行し、生成された ZIP ファイルを Release asset としてアップロードする workflow を追加します。

## 変更内容

- `.github/workflows/release-build.yml` を追加
- `release` イベントの `published` で workflow が起動するよう設定
- `contents: write` 権限を設定
- `ubuntu-latest` 上で以下を実行
  - `actions/checkout@v4`
  - `actions/setup-node@v4`
  - `npm ci`
  - `npm run build`
- `bundle` 配下から `mikuproject-skills-*.zip` を探索
- `gh release upload` で対象 Release に ZIP を添付
- `--clobber` を指定して同名 asset の上書きに対応

## 期待される動作

- Release が `published` されると workflow が起動する
- ビルド成功後、生成された ZIP が Release asset に追加される
- `bundle` 配下に対象 ZIP が見つからない場合は workflow が失敗する

## 影響範囲

- GitHub Actions workflow の追加のみ