### PR TITLE
release-build の権限スコープを job 単位へ移し、ZIP 日付生成を JST 基準に変更

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,12 +5,11 @@ on:
     types:
       - published
 
-permissions:
-  contents: write
-
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/scripts/build-skill-bundle-zip.mjs
+++ b/scripts/build-skill-bundle-zip.mjs
@@ -11,7 +11,12 @@ const repoRoot = path.resolve(__dirname, "..");
 const bundleParentRoot = path.resolve(repoRoot, "bundle");
 const bundleDirName = "mikuproject-skills";
 const bundleRoot = path.resolve(bundleParentRoot, bundleDirName);
-const buildDate = new Date().toISOString().slice(0, 10).replaceAll("-", "");
+const buildDate = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit"
+}).format(new Date()).replaceAll("-", "");
 const zipFileName = `mikuproject-skills-${buildDate}.zip`;
 const zipPath = path.resolve(bundleParentRoot, zipFileName);
 


### PR DESCRIPTION
## 概要

- `release-build.yml` の `contents: write` を workflow 全体ではなく job 単位に移動
- リリース ZIP ファイル名の日付生成を UTC ベースから JST ベースに変更

## 変更内容

### GitHub Actions 権限の見直し

- `release-build.yml` でトップレベルに定義していた `permissions: contents: write` を削除
- `build-and-upload` job 配下に `permissions: contents: write` を移動

### ZIP 日付生成の調整

- `build-skill-bundle-zip.mjs` の `buildDate` 生成処理を変更
- `new Date().toISOString().slice(0, 10).replaceAll("-", "")` を廃止
- `Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Tokyo", year: "numeric", month: "2-digit", day: "2-digit" })` を使う形に変更

## 期待される効果

- Release asset のアップロードに必要な書き込み権限を job 単位に限定できる
- リリース ZIP ファイル名の日付が JST 基準で生成される

## 確認事項

- 影響範囲: `.github/workflows/release-build.yml` と `scripts/build-skill-bundle-zip.mjs`