### PR TITLE
Agent Skillsのランタイム成果物方針を追記

### DIFF
--- a/docs/miku-soft-40-agentskills-design-v20260425.md
+++ b/docs/miku-soft-40-agentskills-design-v20260425.md
@@ -214,6 +214,12 @@ This keeps agent behavior predictable. It also prevents the skill from accidenta
 
 Runtime artifact lookup should be simple and fixed. Place the single jar and single JavaScript CLI file under the skill directory, such as `skills/<skill-name>/runtime/`, and let the skill use those declared paths.
 
+Do not create a separate skill product line only because an additional runtime path exists. When both Java CLI and Node.js CLI runtimes are available, treat them as runtime artifacts of the same normal `-skills` package. The skill name, activation rules, workflow vocabulary, artifact roles, and product boundary should remain tied to the upstream main application, not to the runtime implementation.
+
+When both Java CLI and Node.js CLI runtime artifacts are bundled, the skill may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the skill may fall back to the Node.js CLI runtime.
+
+This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
 ### AI-Facing Spec Retrieval Principles
 
 Agent Skills should not rely on broad file search to find prompt or spec documents.
@@ -431,6 +437,7 @@ Test coverage should include:
 
 - skill smoke tests
 - upstream runtime availability checks
+- runtime selection checks, including Java CLI available, Java CLI unavailable with Node.js fallback, unsupported Java CLI operation with Node.js fallback, and all runtimes missing as a hard error
 - representative import / export operations
 - draft / patch / validate / apply operations where applicable
 - diagnostics and hard-error behavior
@@ -502,6 +509,22 @@ repository root
 ```
 
 In the TOBE target shape, runtime artifacts should be placed under each skill directory. Do not design new normal operation around root-level runtime artifacts, vendored source trees, or multiple competing runtime lookup paths. Current repositories that still use a vendored runtime tree should document that as a transition state and keep the lookup path explicit.
+
+For example, `mikuproject-skills` should move toward this shape when both runtime paths are available.
+
+```text
+skills/
+  mikuproject/
+    SKILL.md
+    references/
+    runtime/
+      mikuproject.jar
+      mikuproject.mjs
+```
+
+The Java jar and Node.js CLI file are peer runtime artifacts. Their presence should not change the skill name or split the workflow vocabulary into runtime-specific skill products.
+
+`vendor/` directories are transition-only locations for repositories that still depend on copied upstream source trees or broader runtime trees. New normal operation should not add new runtime lookup through `vendor/`. As upstream Java and Node.js CLI artifacts become available as single files, repositories should move those artifacts into `skills/<skill-name>/runtime/` and remove the vendored runtime tree.
 
 ### Skill Naming Conventions
 


### PR DESCRIPTION
## 概要

- `docs/miku-soft-40-agentskills-design-v20260425.md` に、Java CLI と Node.js CLI の両方を扱う場合のランタイム方針を追記しました。
- 追加ランタイムが存在するだけで別の skill 製品系列を作らず、同一の通常 `-skills` パッケージ内のランタイム成果物として扱う方針を明記しました。
- Java CLI を優先し、利用不可または対象操作に未対応の場合に Node.js CLI へフォールバックする実行方針を追記しました。
- ランタイム選択に関するテスト観点と、`skills/<skill-name>/runtime/` 配下に単一 jar / 単一 JavaScript CLI ファイルを配置する推奨構成を追記しました。
- `vendor/` は移行期間中の場所であり、新しい通常運用では runtime 配下への移行を目指す方針を明記しました。

## 変更内容

- Core Runtime Principles に、ランタイム実装と skill の意味的境界を分離する説明を追加
- Testing Principles に、Java CLI 利用可否、Node.js フォールバック、全ランタイム欠如時のハードエラーを確認する観点を追加
- Repository Shape に、`mikuproject-skills` を例にした runtime 配置例を追加
- Java jar と Node.js CLI ファイルを peer runtime artifact として扱う方針を追加

## 確認

- ドキュメント追記のみの変更です。
- テスト実行の有無は未確認です。