### PR TITLE
Java / Node.js runtime のCLI対応関係とTOBE Java facade案を整理

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -119,6 +119,23 @@
 - [x] `mikuproject-skills` 側だけで無理に実装せず、upstream (`mikuproject`) 側の API 追加や公開面整理が妥当な場合は、その都度 `mikuproject` 側アクション候補として相談する
 - [ ] upstream の Java CLI runtime artifact と Node.js CLI runtime artifact に `--version` を追加してもらう
   - `mikuproject.jar` / `mikuproject.mjs` はファイル名に version が含まれないため、受け取った artifact の由来や新旧を CLI から判別できる必要がある
+- [ ] upstream `mikuproject-java` 側で、Node.js runtime の agent-friendly な CLI 引数体系に寄せた Java facade command を追加してもらう
+  - `mikuproject-skills` 側の実装項目ではなく、`mikuproject-java` 側メンバーへの TODO として扱う
+  - 現状の Java CLI は XML と位置引数を中心にした低レベル command が多く、Node.js CLI は `ai spec`、`state from-draft --in --out`、`state apply-patch --state --in --out`、`report all --in --out` のように生成AIが組み立てやすい
+  - 既存 Java command は残しつつ、生成AI向けには Node.js CLI と近い階層・命名・`--in` / `--out` 引数を持つ入口を追加するのが望ましい
+- [ ] upstream `mikuproject-java` 側で、agent-friendly Java facade command 追加時に `output.xlsxbin` のような分かりにくい拡張子をユーザー向け例示から消せるか確認してもらう
+  - コマンド体系を Node.js runtime 側へ寄せるなら、構造 workbook `XLSX` や report `WBS XLSX` の出力例も `.xlsx` のような自然な拡張子で示せることが期待される
+  - 内部実装上の都合で `xlsxbin` 相当の概念が残る場合でも、生成AI向け・利用者向けの facade CLI では露出しない形にできるかを確認する
+- [ ] upstream `mikuproject-java` 側で、ASIS 対応表に `Not available as a direct Java command` と記録した操作の Java 実装を追加してもらう
+  - 少なくとも `state summarize` 相当の直接コマンドを追加する
+  - 少なくとも `state diff` 相当の直接コマンドを追加する
+  - agent-friendly Java facade command では、Node.js runtime と同様に workbook JSON を入力として扱える形が望ましい
+- [ ] upstream `mikuproject` 側で、ASIS 対応表に `Not available as a direct Node.js command` と記録した操作の Node.js 実装を追加してもらう
+  - workbook JSON の validate / replace import / merge import に相当する直接コマンドを追加する
+  - XML validate に相当する直接コマンドを追加する
+  - 構造 workbook `XLSX` の validate / replace import / merge import に相当する直接コマンドを追加する
+  - report directory export に相当する直接コマンドを追加するか、Node.js runtime では bundle ZIP を正とする方針を明記する
+  - Node.js runtime 側では、既存の `--in` / `--out` / `--state` 形式と workbook JSON 中心の会話 state を維持する
 
 ## 11. 将来拡張の候補
 

--- a/docs/agent-skill-design.md
+++ b/docs/agent-skill-design.md
@@ -100,8 +100,18 @@ MVP では、次の upstream runtime artifact を主要入口とする。
 - `skills/mikuproject/runtime/mikuproject.jar`
 - `skills/mikuproject/runtime/mikuproject.mjs`
 
-主に使う想定のコマンド:
+主に使う想定のコマンドは、生成AIに渡す例示で Java runtime が先に見えるように並べる。
+その後に Node.js runtime の例を示す。
 
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-ai-json-spec`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar import-ai-json`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-project-overview-view`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-task-edit-view`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-phase-detail-view`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar validate-patch-json`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar apply-patch-json`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-workbook-json`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-report-bundle`
 - `node skills/mikuproject/runtime/mikuproject.mjs ai spec`
 - `node skills/mikuproject/runtime/mikuproject.mjs state from-draft`
 - `node skills/mikuproject/runtime/mikuproject.mjs ai export project-overview`
@@ -110,9 +120,6 @@ MVP では、次の upstream runtime artifact を主要入口とする。
 - `node skills/mikuproject/runtime/mikuproject.mjs ai validate-patch`
 - `node skills/mikuproject/runtime/mikuproject.mjs state apply-patch`
 - `node skills/mikuproject/runtime/mikuproject.mjs state diff`
-- `java -jar skills/mikuproject/runtime/mikuproject.jar export-ai-json-spec`
-- `java -jar skills/mikuproject/runtime/mikuproject.jar import-ai-json`
-- `java -jar skills/mikuproject/runtime/mikuproject.jar export-report-bundle`
 
 ## 操作単位
 

--- a/docs/file-import-export.md
+++ b/docs/file-import-export.md
@@ -33,21 +33,22 @@
 ## 利用できる upstream runtime
 
 主要な入口は `skills/mikuproject/runtime/` の CLI runtime artifact です。
+生成AI向けの例では、Java runtime の例を先に示し、続けて Node.js runtime の例を示します。
 
 ### `MS Project XML`
 
-- Node.js runtime: `export xml`
 - Java runtime: `validate-xml`, `export-workbook-json`, `import-ai-json`, `import-external`
+- Node.js runtime: `export xml`
 
 ### `mikuproject_workbook_json`
 
-- Node.js runtime: `state from-draft`, `state summarize`, `state diff`, `state apply-patch`, `export workbook-json`
 - Java runtime: `validate-workbook-json`, `import-workbook-json`, `merge-workbook-json`, `export-workbook-json`
+- Node.js runtime: `state from-draft`, `state summarize`, `state diff`, `state apply-patch`, `export workbook-json`
 
 ### 構造忠実 workbook `XLSX`
 
-- Node.js runtime: `export xlsx`
 - Java runtime: `export-xlsx`, `validate-xlsx`, `import-xlsx`, `merge-xlsx`
+- Node.js runtime: `export xlsx`
 
 ## `MS Project XML`
 

--- a/docs/report-export.md
+++ b/docs/report-export.md
@@ -32,9 +32,10 @@
 ## 利用できる upstream runtime
 
 主要な入口は `skills/mikuproject/runtime/` の CLI runtime artifact です。
+生成AI向けの例では、Java runtime の例を先に示し、続けて Node.js runtime の例を示します。
 
-- Node.js runtime: `report all`, `report wbs-xlsx`, `report daily-svg`, `report weekly-svg`, `report monthly-calendar-svg`, `report wbs-markdown`, `report mermaid`
 - Java runtime: `export-report-bundle`, `export-report-dir`, `export-wbs-xlsx`, `export-daily-svg`, `export-weekly-svg`, `export-monthly-svg-zip`, `export-wbs-markdown`, `export-mermaid`
+- Node.js runtime: `report all`, `report wbs-xlsx`, `report daily-svg`, `report weekly-svg`, `report monthly-calendar-svg`, `report wbs-markdown`, `report mermaid`
 
 ## `WBS XLSX`
 

--- a/skills/mikuproject/references/io/workbook-import-export.md
+++ b/skills/mikuproject/references/io/workbook-import-export.md
@@ -8,10 +8,11 @@ This is different from the conversational handoff use case because the focus her
 
 Prefer the bundled runtime CLI commands:
 
-- `node skills/mikuproject/runtime/mikuproject.mjs export workbook-json --in workbook.json --out workbook.normalized.json`
 - `java -jar skills/mikuproject/runtime/mikuproject.jar validate-workbook-json input.json`
 - `java -jar skills/mikuproject/runtime/mikuproject.jar import-workbook-json input.json output.xml`
 - `java -jar skills/mikuproject/runtime/mikuproject.jar merge-workbook-json base.xml input.json output.xml`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-workbook-json input.xml`
+- `node skills/mikuproject/runtime/mikuproject.mjs export workbook-json --in workbook.json --out workbook.normalized.json`
 
 ## `workbook-import`
 

--- a/skills/mikuproject/references/runtime/operations-map.md
+++ b/skills/mikuproject/references/runtime/operations-map.md
@@ -53,9 +53,109 @@ Do not search broadly for alternate copies before checking these expected locati
 
 ## Preferred Runtime Surface
 
-Prefer:
+List Java examples before Node.js examples so agents see the Java runtime first.
+Use the runtime that supports the requested operation:
 
 - `java -jar skills/mikuproject/runtime/mikuproject.jar ...`
 - `node skills/mikuproject/runtime/mikuproject.mjs ...`
 
 Use the upstream CLI runtime artifacts before falling back to direct file reads or UI-oriented flows.
+
+## Java / Node.js CLI Correspondence
+
+The Java and Node.js runtime CLIs do not use the same argument shape.
+The examples below intentionally list Java first, then the closest Node.js command when one exists.
+
+| Operation | Java CLI example | Node.js CLI example | Notes |
+| --- | --- | --- | --- |
+| Version | `java -jar skills/mikuproject/runtime/mikuproject.jar --version` | `node skills/mikuproject/runtime/mikuproject.mjs --version` | Same purpose. |
+| AI JSON spec | `java -jar skills/mikuproject/runtime/mikuproject.jar export-ai-json-spec` | `node skills/mikuproject/runtime/mikuproject.mjs ai spec` | Same purpose. |
+| Draft import | `java -jar skills/mikuproject/runtime/mikuproject.jar import-ai-json draft.editjson output.xml` | `node skills/mikuproject/runtime/mikuproject.mjs state from-draft --in draft.editjson --out workbook.json` | Java writes XML. Node writes workbook JSON. Use Java `export-workbook-json output.xml` when workbook JSON is needed after Java import. |
+| AI document kind detection | `java -jar skills/mikuproject/runtime/mikuproject.jar detect-ai-json-kind input.txt` | `node skills/mikuproject/runtime/mikuproject.mjs ai detect-kind --in document.json` | Similar purpose, different arguments. |
+| Workbook JSON validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate-workbook-json input.json` | Not available as a direct Node.js command | Java-only direct validation command in the current CLI surface. |
+| Workbook JSON replace import | `java -jar skills/mikuproject/runtime/mikuproject.jar import-workbook-json input.json output.xml` | Not available as a direct Node.js command | Java writes XML. Node generally treats workbook JSON as state input. |
+| Workbook JSON merge import | `java -jar skills/mikuproject/runtime/mikuproject.jar merge-workbook-json base.xml input.json output.xml` | Not available as a direct Node.js command | Java-only direct merge command in the current CLI surface. |
+| Workbook JSON export / normalize | `java -jar skills/mikuproject/runtime/mikuproject.jar export-workbook-json input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs export workbook-json --in workbook.json --out workbook.normalized.json` | Java reads XML. Node reads workbook JSON. |
+| Project overview view | `java -jar skills/mikuproject/runtime/mikuproject.jar export-project-overview-view input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs ai export project-overview --in workbook.json --out overview.editjson` | Java reads XML. Node reads workbook JSON. |
+| Task edit view | `java -jar skills/mikuproject/runtime/mikuproject.jar export-task-edit-view input.xml taskUid` | `node skills/mikuproject/runtime/mikuproject.mjs ai export task-edit --in workbook.json --task-uid taskUid --out task.editjson` | Java reads XML. Node reads workbook JSON. |
+| Phase detail view | `java -jar skills/mikuproject/runtime/mikuproject.jar export-phase-detail-view input.xml phaseUid` | `node skills/mikuproject/runtime/mikuproject.mjs ai export phase-detail --in workbook.json --phase-uid phaseUid --out phase.editjson` | Java reads XML. Node reads workbook JSON. |
+| Patch validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate-patch-json patch.editjson` | `node skills/mikuproject/runtime/mikuproject.mjs ai validate-patch --state workbook.json --in patch.editjson` | Java validates the patch document. Node validates against workbook state. |
+| Patch apply | `java -jar skills/mikuproject/runtime/mikuproject.jar apply-patch-json base.xml patch.editjson output.xml` | `node skills/mikuproject/runtime/mikuproject.mjs state apply-patch --state workbook.json --in patch.editjson --out workbook.next.json` | Java uses XML state. Node uses workbook JSON state. |
+| State summary | Not available as a direct Java command | `node skills/mikuproject/runtime/mikuproject.mjs state summarize --in workbook.json` | Node-only direct command in the current CLI surface. |
+| State diff | Not available as a direct Java command | `node skills/mikuproject/runtime/mikuproject.mjs state diff --before workbook.before.json --after workbook.after.json` | Node-only direct command in the current CLI surface. |
+| XML validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate-xml input.xml` | Not available as a direct Node.js command | Java-only direct validation command in the current CLI surface. |
+| XML export | Indirect through Java XML-producing commands such as `import-ai-json`, `import-workbook-json`, `apply-patch-json`, or `merge-workbook-json` | `node skills/mikuproject/runtime/mikuproject.mjs export xml --in workbook.json --out project.xml` | Node directly exports XML from workbook JSON. Java commands commonly use XML as input/output. |
+| Structural XLSX export | `java -jar skills/mikuproject/runtime/mikuproject.jar export-xlsx input.xml output.xlsxbin` | `node skills/mikuproject/runtime/mikuproject.mjs export xlsx --in workbook.json --out project.xlsx` | Java reads XML. Node reads workbook JSON. |
+| Structural XLSX validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate-xlsx input.xlsxbin` | Not available as a direct Node.js command | Java-only direct validation command in the current CLI surface. |
+| Structural XLSX replace import | `java -jar skills/mikuproject/runtime/mikuproject.jar import-xlsx input.xlsxbin output.xml` | Not available as a direct Node.js command | Java-only direct import command in the current CLI surface. |
+| Structural XLSX merge import | `java -jar skills/mikuproject/runtime/mikuproject.jar merge-xlsx base.xml input.xlsxbin output.xml` | Not available as a direct Node.js command | Java-only direct merge command in the current CLI surface. |
+| Report bundle | `java -jar skills/mikuproject/runtime/mikuproject.jar export-report-bundle input.xml output.zip` | `node skills/mikuproject/runtime/mikuproject.mjs report all --in workbook.json --out report-bundle.zip` | Java reads XML. Node reads workbook JSON. |
+| Report directory | `java -jar skills/mikuproject/runtime/mikuproject.jar export-report-dir input.xml output.dir` | Not available as a direct Node.js command | Java-only direct directory export command in the current CLI surface. |
+| WBS XLSX report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-wbs-xlsx input.xml output.xlsxbin` | `node skills/mikuproject/runtime/mikuproject.mjs report wbs-xlsx --in workbook.json --out report.xlsx` | Java reads XML. Node reads workbook JSON. |
+| Daily SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-daily-svg input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs report daily-svg --in workbook.json --out report.svg` | Java reads XML. Node reads workbook JSON. |
+| Weekly SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-weekly-svg input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs report weekly-svg --in workbook.json --out report.svg` | Java reads XML. Node reads workbook JSON. |
+| Monthly SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-monthly-svg-zip input.xml output.zip` | `node skills/mikuproject/runtime/mikuproject.mjs report monthly-calendar-svg --in workbook.json --out report.zip` | Java reads XML. Node reads workbook JSON. |
+| WBS Markdown report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-wbs-markdown input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs report wbs-markdown --in workbook.json --out report.md` | Java reads XML. Node reads workbook JSON. |
+| Mermaid report | `java -jar skills/mikuproject/runtime/mikuproject.jar export-mermaid input.xml` | `node skills/mikuproject/runtime/mikuproject.mjs report mermaid --in workbook.json --out report.mmd` | Java reads XML. Node reads workbook JSON. |
+
+Batch commands such as `*-batch` exist on the Java runtime for several operations.
+The Node.js runtime examples above are single-operation commands.
+
+## TOBE Java Facade CLI Proposal
+
+This section is a proposal for a future `mikuproject-java` facade CLI.
+It is not the current Java CLI contract.
+
+The goal is to keep Java as the first example shown to agents while reducing confusion from
+the current XML-first positional-argument commands.
+The proposed facade should use the same operation grouping style as the Node.js runtime:
+
+- `ai ...` for AI-facing specs and projections
+- `state ...` for workbook JSON state operations
+- `export ...` for exchange-format exports
+- `report ...` for presentation/report outputs
+- `--in`, `--out`, `--state`, `--before`, and `--after` for named file arguments
+- `.xlsx` for visible XLSX files, not `output.xlsxbin`
+
+Proposed Java facade examples:
+
+| Operation | TOBE Java facade example | Notes |
+| --- | --- | --- |
+| Version | `java -jar skills/mikuproject/runtime/mikuproject.jar --version` | Keep the existing simple version shape. |
+| AI JSON spec | `java -jar skills/mikuproject/runtime/mikuproject.jar ai spec` | Mirrors Node.js `ai spec`. |
+| Draft import | `java -jar skills/mikuproject/runtime/mikuproject.jar state from-draft --in draft.editjson --out workbook.json` | Reads `project_draft_view`, writes workbook JSON directly. |
+| AI document kind detection | `java -jar skills/mikuproject/runtime/mikuproject.jar ai detect-kind --in document.json` | Uses the same grouped naming as Node.js. |
+| Workbook JSON validation | `java -jar skills/mikuproject/runtime/mikuproject.jar state validate --in workbook.json` | Keeps validation under `state`. |
+| Workbook JSON replace import | `java -jar skills/mikuproject/runtime/mikuproject.jar state import --in workbook.json --out workbook.normalized.json` | Normalizes or accepts workbook JSON without exposing XML. |
+| Workbook JSON merge import | `java -jar skills/mikuproject/runtime/mikuproject.jar state merge --state workbook.json --in workbook.patch.json --out workbook.next.json` | Uses workbook JSON as the visible state boundary. |
+| Workbook JSON export / normalize | `java -jar skills/mikuproject/runtime/mikuproject.jar export workbook-json --in workbook.json --out workbook.normalized.json` | Mirrors Node.js `export workbook-json`. |
+| Project overview view | `java -jar skills/mikuproject/runtime/mikuproject.jar ai export project-overview --in workbook.json --out overview.editjson` | Reads workbook JSON, writes projection JSON. |
+| Task edit view | `java -jar skills/mikuproject/runtime/mikuproject.jar ai export task-edit --in workbook.json --task-uid taskUid --out task.editjson` | Uses a named task UID option. |
+| Phase detail view | `java -jar skills/mikuproject/runtime/mikuproject.jar ai export phase-detail --in workbook.json --phase-uid phaseUid --out phase.editjson` | Uses named phase and output options. |
+| Patch validation | `java -jar skills/mikuproject/runtime/mikuproject.jar ai validate-patch --state workbook.json --in patch.editjson` | Validates against the visible workbook JSON state. |
+| Patch apply | `java -jar skills/mikuproject/runtime/mikuproject.jar state apply-patch --state workbook.json --in patch.editjson --out workbook.next.json` | Reads and writes workbook JSON directly. |
+| State summary | `java -jar skills/mikuproject/runtime/mikuproject.jar state summarize --in workbook.json` | Adds Java parity for the Node.js state summary command. |
+| State diff | `java -jar skills/mikuproject/runtime/mikuproject.jar state diff --before workbook.before.json --after workbook.after.json` | Adds Java parity for the Node.js state diff command. |
+| XML validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate xml --in project.xml` | Uses named input while keeping XML validation explicit. |
+| XML export | `java -jar skills/mikuproject/runtime/mikuproject.jar export xml --in workbook.json --out project.xml` | Exports XML from workbook JSON without exposing intermediate XML-only workflows. |
+| Structural XLSX export | `java -jar skills/mikuproject/runtime/mikuproject.jar export xlsx --in workbook.json --out workbook.xlsx` | Uses `.xlsx`, not `.xlsxbin`, in the facade. |
+| Structural XLSX validation | `java -jar skills/mikuproject/runtime/mikuproject.jar validate xlsx --in workbook.xlsx` | Uses visible `.xlsx` naming. |
+| Structural XLSX replace import | `java -jar skills/mikuproject/runtime/mikuproject.jar import xlsx --in workbook.xlsx --out workbook.json` | Imports `.xlsx` to workbook JSON directly. |
+| Structural XLSX merge import | `java -jar skills/mikuproject/runtime/mikuproject.jar merge xlsx --state workbook.json --in workbook.xlsx --out workbook.next.json` | Merges visible `.xlsx` edits into workbook JSON state. |
+| Report bundle | `java -jar skills/mikuproject/runtime/mikuproject.jar report all --in workbook.json --out report-bundle.zip` | Mirrors Node.js `report all`. |
+| Report directory | `java -jar skills/mikuproject/runtime/mikuproject.jar report dir --in workbook.json --out report.dir` | Java-specific convenience can remain, but uses named args. |
+| WBS XLSX report | `java -jar skills/mikuproject/runtime/mikuproject.jar report wbs-xlsx --in workbook.json --out wbs.xlsx` | Uses `.xlsx` for visible report output. |
+| Daily SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar report daily-svg --in workbook.json --out daily.svg` | Mirrors Node.js report grouping. |
+| Weekly SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar report weekly-svg --in workbook.json --out weekly.svg` | Mirrors Node.js report grouping. |
+| Monthly SVG report | `java -jar skills/mikuproject/runtime/mikuproject.jar report monthly-calendar-svg --in workbook.json --out monthly-calendar.zip` | Uses a descriptive ZIP output name. |
+| WBS Markdown report | `java -jar skills/mikuproject/runtime/mikuproject.jar report wbs-markdown --in workbook.json --out wbs.md` | Mirrors Node.js report grouping. |
+| Mermaid report | `java -jar skills/mikuproject/runtime/mikuproject.jar report mermaid --in workbook.json --out mermaid.mmd` | Mirrors Node.js report grouping. |
+
+Guidance for implementing the facade in `mikuproject-java`:
+
+- Keep the existing Java CLI commands for compatibility.
+- Treat the facade as an agent-facing and user-facing layer over the existing Java implementation.
+- Prefer workbook JSON as the visible state boundary for `state`, `ai`, `export`, and `report` facade commands.
+- Hide XML intermediates unless the command is explicitly about XML.
+- Hide implementation-specific binary naming such as `xlsxbin` from facade examples and outputs.
+- Keep option names close to the Node.js runtime where the behavior is equivalent.

--- a/skills/mikuproject/references/workflow/draft-import.md
+++ b/skills/mikuproject/references/workflow/draft-import.md
@@ -9,13 +9,14 @@ Accept either:
 - raw JSON text
 - a full LLM response that ends with a `json` fenced block
 
-Prefer the Node.js runtime command:
-
-- `node skills/mikuproject/runtime/mikuproject.mjs state from-draft --in draft.editjson --out workbook.json`
-
-The Java runtime can also import AI JSON to XML:
+Show the Java runtime path first:
 
 - `java -jar skills/mikuproject/runtime/mikuproject.jar import-ai-json draft.editjson output.xml`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-workbook-json output.xml > workbook.json`
+
+Node.js runtime example:
+
+- `node skills/mikuproject/runtime/mikuproject.mjs state from-draft --in draft.editjson --out workbook.json`
 
 ## Required Kind
 

--- a/skills/mikuproject/references/workflow/patch-import.md
+++ b/skills/mikuproject/references/workflow/patch-import.md
@@ -7,7 +7,14 @@ Use this reference when the user provides AI output that should be treated as `P
 `Patch JSON` cannot be applied by itself.
 Require an existing `mikuproject_workbook_json` as the base state.
 
-Use the Node.js runtime command:
+Show the Java runtime path first:
+
+- `java -jar skills/mikuproject/runtime/mikuproject.jar import-workbook-json workbook.json base.xml`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar validate-patch-json patch.editjson`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar apply-patch-json base.xml patch.editjson output.xml`
+- `java -jar skills/mikuproject/runtime/mikuproject.jar export-workbook-json output.xml > workbook.next.json`
+
+Node.js runtime example:
 
 - `node skills/mikuproject/runtime/mikuproject.mjs state apply-patch --state workbook.json --in patch.editjson --out workbook.next.json`
 
@@ -18,13 +25,9 @@ Accept either:
 - raw JSON text
 - a full LLM response that ends with a `json` fenced block
 
-For validation, prefer:
+For validation through the Node.js runtime:
 
 - `node skills/mikuproject/runtime/mikuproject.mjs ai validate-patch --state workbook.json --in patch.editjson`
-
-The Java runtime can apply a patch when the base is XML:
-
-- `java -jar skills/mikuproject/runtime/mikuproject.jar apply-patch-json base.xml patch.editjson output.xml`
 
 ## Required Kind
 


### PR DESCRIPTION
## 概要

`mikuproject` skill の runtime 参照ドキュメントを更新し、Java runtime と Node.js runtime のCLI対応関係を整理しました。

あわせて、現状のJava CLIがXML中心・位置引数中心であることを踏まえ、将来の `mikuproject-java` 向けに Node.js runtime のような agent-friendly な facade CLI 案を追記しました。

## 変更内容

- `operations-map.md` に Java / Node.js CLI のASIS対応表を追加
  - Java CLI と Node.js CLI は同じ引数体系ではないことを明記
  - Java例を先、Node.js例を後に並べる方針を明記
  - Java側のみ、Node.js側のみ、入出力形式が異なる操作を表で整理
- `operations-map.md` に TOBE Java facade CLI 案を追加
  - `ai ...`
  - `state ...`
  - `export ...`
  - `report ...`
  - `--in` / `--out` / `--state` / `--before` / `--after`
  - `.xlsx` を使い、`output.xlsxbin` のような実装寄りの拡張子を facade から隠す方針
- 生成AI向けの例示で Java runtime が先に見えるよう、関連ドキュメントのコマンド例順を調整
- draft import / patch import の参照ドキュメントで、Java runtime path を先に示し、その後に Node.js runtime 例を示す形へ変更
- workbook JSON import/export の参照ドキュメントで Java runtime 例を先に整理
- `TODO.md` に upstream 側へのTODOを追加
  - `mikuproject-java` 側で Node.js runtime の agent-friendly なCLI体系に寄せた Java facade command を追加する
  - `mikuproject-java` 側で `output.xlsxbin` のような分かりにくい拡張子をユーザー向け例示から消せるか確認する
  - `mikuproject-java` 側で `state summarize` / `state diff` 相当の直接コマンドを追加する
  - `mikuproject` 側で Javaにはあるが Node.jsには直接コマンドがない操作を追加する

## 対象ファイル

- `TODO.md`
- `docs/agent-skill-design.md`
- `docs/file-import-export.md`
- `docs/report-export.md`
- `skills/mikuproject/references/io/workbook-import-export.md`
- `skills/mikuproject/references/runtime/operations-map.md`
- `skills/mikuproject/references/workflow/draft-import.md`
- `skills/mikuproject/references/workflow/patch-import.md`

## 確認内容

- テスト実行は未確認です。
- この変更はドキュメントとTODOの整理です。