### PR TITLE
Javaアプリ設計メモを20260426版へ更新

### DIFF
--- a/docs/miku-soft-20-javaapp-design-v20260426.md
+++ b/docs/miku-soft-20-javaapp-design-v20260426.md
@@ -1,4 +1,4 @@
-# Miku Software Java Application Design v20260425
+# Miku Software Java Application Design v20260426
 
 This memo organizes design characteristics commonly expected for Java application versions in the `miku` software series.
 
@@ -302,9 +302,12 @@ Java applications package local runtime use explicitly.
 
 The default runtime artifact is a single executable fat jar.
 
+The normal Maven package should also attach a sources jar, such as `<artifactId>-<version>-sources.jar`. The sources jar is a traceability and publication artifact, not the executable runtime artifact.
+
 When a distribution zip is useful, it should contain the minimal runtime-user-facing items such as:
 
 - runtime jar
+- sources jar when publishing or downstream traceability needs it
 - `README.md`
 - `LICENSE`
 - CLI or runtime docs where useful
@@ -316,6 +319,7 @@ The basic naming direction is:
 - Maven `groupId`: `jp.igapyon`
 - Maven `artifactId`: product-derived artifact name
 - jar name: `<artifactId>-<version>.jar`
+- sources jar name: `<artifactId>-<version>-sources.jar`
 - distribution zip name: `<artifactId>-dist-<version>.zip` or a similarly traceable form
 
 Runtime artifacts should not depend on source-tree-relative paths. If runtime markdown, prompt specs, or templates are needed inside the jar, copy them to classpath resources and read them through `getResourceAsStream` or an equivalent jar-safe mechanism.
@@ -842,9 +846,10 @@ The repository currently uses a single Maven project.
 The expected runtime artifacts are:
 
 - `target/mikuproject.jar`
+- `target/mikuproject-sources.jar`
 - `target/mikuproject-dist.zip`
 
-The distribution zip contains the runtime jar and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
+The distribution zip contains the runtime jar, sources jar, and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
 
 This single-module shape should remain acceptable while there is no Maven plugin deliverable. If a Maven plugin is added later, the repository should be reconsidered as a multi-module Maven reactor so that plugin code remains a thin adapter over the runtime / core API rather than a second implementation.
 


### PR DESCRIPTION
## 概要

miku Java application design memo を `v20260426` 版へ更新します。

旧版の `docs/miku-soft-20-javaapp-design-v20260425.md` を削除し、新版の `docs/miku-soft-20-javaapp-design-v20260426.md` を追加しています。

## 変更内容

- Java application design memo の版を `v20260425` から `v20260426` に更新
- Packaging and Distribution Principles に sources jar の扱いを追記
  - 通常の Maven package で sources jar を attach する方針を明記
  - sources jar は executable runtime artifact ではなく、traceability / publication artifact として扱うことを明記
  - distribution zip に sources jar を含める場合の方針を追記
  - sources jar の命名例を追記
- `mikuproject-java` の Repository Shape に expected runtime artifact として `target/mikuproject-sources.jar` を追加
- `mikuproject-java` の distribution zip について、runtime jar と sources jar を含む形に説明を更新

## テスト

このコミットはドキュメント更新のみであり、テスト実行結果は不要