### PR TITLE
MCP設計書をv20260427へ更新しNode.js/TypeScript方針を明確化

### DIFF
--- a/docs/miku-soft-00-overview-design-v20260427.md
+++ b/docs/miku-soft-00-overview-design-v20260427.md
@@ -19,7 +19,7 @@ The series is not organized around a single UI, runtime, or protocol. It is orga
 - Provide Node.js CLI surfaces as normal main-application surfaces
 - Provide Java 1.8 CLI runtimes through straight conversion as a normal follow-up deliverable
 - Package Agent Skills with instructions, operation maps, references, and executable CLI runtime artifacts
-- Provide MCP servers when there is no product-specific reason to avoid them
+- Provide MCP servers in Node.js / TypeScript when there is no product-specific reason to avoid them
 - Keep Java versions, Agent Skills, and MCP servers downstream of the upstream product semantics
 - Preserve artifact roles, diagnostics, local execution, and runtime traceability across layers
 
@@ -48,7 +48,7 @@ The detailed documents are organized by layer and concern.
 - `docs/miku-soft-40-agentskills-design-v*.md`
   - describes Agent Skills packages, including local instructions, operation maps, references, and bundled CLI runtime artifacts for AI agents
 - `docs/miku-soft-50-mcp-design-v*.md`
-  - describes MCP server versions that expose product operations to MCP clients through tools, resources, and prompts
+  - describes Node.js / TypeScript MCP server versions that expose product operations to MCP clients through tools, resources, and prompts
 
 ## Layered Product Shape
 
@@ -144,11 +144,13 @@ The agent-facing layer should especially preserve:
 
 The MCP-facing layer is a normal extension target, not a replacement for Agent Skills.
 
-When there is no product-specific reason to avoid it, a miku product should provide an MCP server for MCP clients.
+When there is no product-specific reason to avoid it, a miku product should provide an MCP server for MCP clients. The standard implementation choice for miku MCP servers is Node.js / TypeScript, using the MCP SDK and keeping the server as a thin protocol adapter.
 
 The MCP server exposes product operations through tools, resources, and prompts. It should remain a protocol adapter over the product runtime, not a replacement implementation.
 
-The MCP server may use the TypeScript / Node.js runtime, the Java runtime, or both. When both runtime artifacts are available, the MCP server should treat runtime choice as an execution policy, not as a change in product semantics.
+The MCP server may execute the TypeScript / Node.js runtime, the Java runtime, or both as product runtime artifacts. This runtime choice is separate from the MCP server implementation language. When both runtime artifacts are available, the MCP server should treat runtime choice as an execution policy, not as a change in product semantics.
+
+Java should not be treated as a default second MCP server implementation. A Java-side directory in an MCP repository may exist as a placeholder, but it should remain a placeholder unless a concrete future distribution or runtime constraint justifies maintaining a Java MCP server.
 
 The MCP-facing layer should keep the following properties.
 
@@ -172,7 +174,7 @@ The usual product flow for the miku software series is as follows.
 4. Produce a single-file Node.js CLI runtime artifact for downstream use.
 5. Create the Java 1.8 CLI runtime through straight conversion unless there is a clear reason not to.
 6. Package Agent Skills with instructions, operation maps, references, and bundled runtime artifacts.
-7. Provide an MCP server when there is no product-specific reason to avoid it.
+7. Provide a Node.js / TypeScript MCP server when there is no product-specific reason to avoid it.
 
 This flow is a default direction, not a reason to blur responsibilities. Each layer must keep the upstream product boundary visible.
 
@@ -190,6 +192,7 @@ The preferred responsibility split is as follows.
   - owns agent-facing instructions, activation rules, workflow maps, local file discipline, runtime lookup, and bundled runtime artifact wiring
 - MCP server
   - owns MCP tools, resources, prompts, transport handling, session or workspace policy, and protocol result formatting
+  - is normally implemented in Node.js / TypeScript; Java runtime artifacts remain runtime inputs, not a default second MCP server
 
 The semantic center should remain with the upstream main application. Runtime, skill, and protocol layers should expose or adapt that center rather than redefining it.
 
@@ -219,6 +222,6 @@ Keeping artifact roles visible makes UI, CLI, Java runtime, Agent Skills, and MC
 
 The miku software series starts from small local products, usually implemented in TypeScript / Node.js, and then exposes the same product meaning through multiple surfaces.
 
-The main application provides the upstream semantic center and normally exposes both a Single-file Web App and a Node.js CLI. Java versions provide Java 1.8 CLI runtimes through straight conversion. Agent Skills package instructions and executable runtime artifacts for AI agents. MCP servers expose product operations through a standard protocol for MCP clients.
+The main application provides the upstream semantic center and normally exposes both a Single-file Web App and a Node.js CLI. Java versions provide Java 1.8 CLI runtimes through straight conversion. Agent Skills package instructions and executable runtime artifacts for AI agents. MCP servers expose product operations through a standard protocol for MCP clients and are normally implemented in Node.js / TypeScript.
 
-The important point is not to multiply implementations. It is to keep one product meaning usable from human UI, local CLI, Java runtime, agent package, and MCP protocol without losing traceability, diagnostics, or artifact discipline.
+The important point is not to multiply implementations. It is to keep one product meaning usable from human UI, local CLI, Java runtime, agent package, and MCP protocol without losing traceability, diagnostics, or artifact discipline. In particular, a Java runtime artifact does not imply that a Java MCP server should also be implemented.

--- a/docs/miku-soft-50-mcp-design-v20260427.md
+++ b/docs/miku-soft-50-mcp-design-v20260427.md
@@ -1,10 +1,10 @@
-# Miku Software MCP Design v20260426
+# Miku Software MCP Design v20260427
 
 This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
 
 The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
 
-The current contents are based on the miku main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and the MCP concepts checked on 2026-04-26.
+The current contents are based on the miku main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and the MCP concepts checked on 2026-04-27.
 
 ## Design Summary
 
@@ -20,10 +20,16 @@ What characterizes MCP server versions is not a new product separate from the up
 - Expose a small number of product-specific prompts when useful
 - Keep local stdio execution as the first implementation target
 - Allow HTTP server deployment as a later transport and hosting variant
+- Use Node.js / TypeScript as the standard MCP server implementation choice
 - Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
 - Treat the MCP server as a thin protocol adapter
 - Keep local and server deployments aligned around the same tool contracts
 - Preserve diagnostics, warnings, and artifact roles in structured results
+
+For the current `mikuproject-mcp` repository, this means the MCP server is
+implemented in Node.js / TypeScript. Runtime artifacts live under `runtime/`;
+`packages/java/` is a placeholder only, not a second MCP server implementation
+target.
 
 ## Role of This Document
 
@@ -33,13 +39,9 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260425.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-20-javaapp-design-v20260425.md`
-  - describes Java runtime versions when they exist
-- `docs/miku-soft-30-straight-conversion-v20260425.md`
-  - describes how Java versions are created from upstream main applications
 - `docs/miku-soft-40-agentskills-design-v20260425.md`
   - describes how Agent Skills versions expose miku workflows to AI agents
-- `docs/miku-soft-50-mcp-design-v20260426.md`
+- `docs/miku-soft-50-mcp-design-v20260427.md`
   - describes how MCP server versions should expose miku workflows to MCP clients
 
 This document separates the following levels.
@@ -49,7 +51,29 @@ This document separates the following levels.
 - **Observed tendencies**: design habits visible in current miku repositories and MCP usage.
 - **Product-specific notes**: design decisions for specific MCP products, recorded as concrete examples.
 
-When a specification is unclear, first check whether the decision preserves upstream meaning and keeps the MCP surface stable for clients. MCP convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make local and server deployments drift into different products.
+When a specification is unclear, first check whether the decision preserves upstream meaning and keeps the MCP surface stable for clients. For products with a documented CLI, look first to the CLI command tree as the source of truth before inventing MCP method names or operation groups. MCP convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make local and server deployments drift into different products.
+
+## MCP Specification Authority
+
+This document defines the miku-series design stance for MCP server products. It does not replace the external MCP protocol specification.
+
+When implementing an MCP server in a miku-series repository, follow MCP-related authorities in the following order.
+
+1. The official specification published at `modelcontextprotocol.io`
+2. The types and schemas provided by the official MCP SDKs
+3. Changes accepted through MCP governance and Specification Enhancement Proposals
+4. Optional compatibility notes for individual MCP clients such as Claude Desktop, Claude Code, IDE clients, or other host applications
+
+The official MCP specification is the primary contract. Client-specific behavior is optional compatibility material, not a source of product semantics and not a reason to change the core protocol shape.
+
+When supporting a specific client, implement the support as a compatibility layer or documented operational note. Do not let client-specific behavior redefine tool names, input schemas, result schemas, resource URI roles, artifact roles, or error categories. If a client requires a workaround, keep the official MCP contract intact and document the workaround as client compatibility behavior.
+
+The preferred order is:
+
+1. Implement the official MCP contract.
+2. Verify behavior with official SDK types and schemas.
+3. Add client compatibility checks where useful.
+4. Document any client-specific behavior separately from the protocol contract.
 
 ## Scope
 
@@ -65,12 +89,6 @@ Main applications:
 - `mikuproject`
 - `mikuscore`
 
-Java application versions:
-
-- `miku-indexgen-java`
-- `mikuproject-java`
-- `miku-xlsx2md-java`
-
 Agent Skills versions:
 
 - `mikuproject-skills`
@@ -81,6 +99,9 @@ MCP server versions:
 - `mikuproject-mcp`
 
 Projects with the `-mcp` suffix are positioned as MCP server adapters for original suffixless tools or their runtime artifacts.
+
+For `mikuproject-mcp`, the server implementation is Node.js / TypeScript.
+`packages/java/` is intentionally only a placeholder.
 
 This document focuses on MCP server versions. It does not define the Web UI conventions for upstream main applications, Java packaging conventions for Java application versions, or skill packaging conventions for Agent Skills repositories.
 
@@ -152,10 +173,10 @@ An MCP server usually exposes one or more of the following.
 - resource definitions for state, specifications, reports, and generated files
 - resource templates for session or workspace-scoped artifacts
 - prompt definitions for product-specific workflows
-- runtime adapters for Java CLI, Node.js CLI, or public APIs
+- runtime adapters for bundled CLI artifacts or public APIs
 - smoke tests for protocol startup and core tool calls
 
-The MCP server is not primarily the browser UI, not primarily a Java port, and not primarily an Agent Skill. It can use Node.js, Java, or another runtime if that is the natural way to call the upstream product, but the MCP layer itself should remain thin.
+The MCP server is not primarily the browser UI, not primarily a runtime port, and not primarily an Agent Skill. For miku MCP repositories, Node.js / TypeScript is the normal MCP server implementation choice. The server can call bundled or configured runtime artifacts if that is the natural way to execute the upstream product, but the MCP layer itself should remain thin.
 
 The center of an MCP server is reliable protocol adaptation: receive a typed tool call, validate arguments, call the upstream runtime, preserve useful state, expose resulting artifacts as resources, and return diagnostics without hiding important constraints.
 
@@ -181,6 +202,8 @@ MCP server versions emphasize the following philosophy.
 - Use upstream API or CLI before writing MCP-local conversion logic
 - Expose only product-specific operations that are useful to MCP clients
 - Keep tool names stable, explicit, and product-prefixed
+- Derive tool names from the upstream CLI command tree when a documented CLI
+  exists
 - Keep intermediate JSON internal when direct tool composition is possible
 - Return generated files as resources or resource links when practical
 - Preserve diagnostics and warnings as part of the result
@@ -194,13 +217,14 @@ The value of an MCP server version is not that it can answer a domain question c
 MCP servers use the following principles as defaults.
 
 - Use a `-mcp` suffix when the MCP server is a separate repository or package
-- Keep the product name in tool names, such as `mikuproject.apply_patch`
+- Keep the product name in tool names
+- When a documented CLI exists, derive MCP tool names from the canonical CLI
+  command tree
 - Use stdio transport as the first local implementation
 - Treat HTTP transport as an additional deployment form, not a separate product contract
-- Use Node.js or TypeScript when that is the simplest way to implement the MCP server
-- Prefer bundled Java CLI and Node.js CLI runtime artifacts when local, reproducible execution needs them
-- Treat the Java CLI runtime artifact as a single jar
-- Treat the Node.js CLI runtime artifact as a single JavaScript file
+- Use Node.js / TypeScript as the standard implementation choice for the MCP server
+- Prefer a single Node.js / TypeScript MCP server unless a concrete product constraint justifies another server implementation
+- Prefer bundled or configured runtime artifacts when local, reproducible execution needs them
 - Prefer upstream public APIs, stable global APIs, or documented CLI commands
 - Keep tool schemas and result schemas under version control
 - Keep repository-level README user-facing and developer details under `docs/`
@@ -218,7 +242,7 @@ Local stdio is appropriate when:
 
 - the user runs an MCP client on the same machine
 - the product reads and writes local files
-- the upstream runtime is available as a local jar, JavaScript file, or CLI command
+- the upstream runtime is available as a local executable artifact or CLI command
 - the workflow benefits from local-first processing and simple installation
 
 HTTP transport is appropriate when:
@@ -272,16 +296,36 @@ MCP tools are the main execution surface.
 
 Tool names should be product-prefixed and stable.
 
+When a product has a documented CLI, first treat the CLI command tree as the
+source of truth. MCP method names should be derived from that tree before any
+MCP-specific shortening, grouping, or convenience naming is considered.
+
+For products with a documented CLI, MCP tool names should preserve the CLI
+command tree. Use this form:
+
+```text
+<product>.<cli command tokens joined by "_">
+```
+
+Omit only the runtime launcher, such as `node mikuproject.mjs` or
+another runtime command. Convert hyphenated CLI tokens to snake_case.
+
+The CLI command group is part of the operation name. Do not shorten
+`ai detect-kind` to `detect_kind`, `ai validate-patch` to `validate_patch`, or
+`state apply-patch` to `apply_patch` in the MCP surface. Shorter names hide the
+upstream command structure and make MCP, CLI diagnostics, tests, and Agent
+Skills documentation harder to compare.
+
 Examples:
 
 - `mikuproject.ai_spec`
-- `mikuproject.detect_kind`
+- `mikuproject.ai_detect_kind`
 - `mikuproject.state_from_draft`
-- `mikuproject.project_overview`
-- `mikuproject.task_edit`
-- `mikuproject.phase_detail`
-- `mikuproject.validate_patch`
-- `mikuproject.apply_patch`
+- `mikuproject.ai_export_project_overview`
+- `mikuproject.ai_export_task_edit`
+- `mikuproject.ai_export_phase_detail`
+- `mikuproject.ai_validate_patch`
+- `mikuproject.state_apply_patch`
 - `mikuproject.state_diff`
 - `mikuproject.export_workbook_json`
 - `mikuproject.report_mermaid`
@@ -337,14 +381,34 @@ MCP servers should use declared runtime artifacts before broad repository explor
 The preferred order is as follows.
 
 1. Check the MCP server configuration
-2. Check bundled runtime artifacts declared by the package
+2. Check bundled runtime artifacts declared by the package under `runtime/`
 3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
 4. Use MCP-local helpers only when they are the intended adapter layer
 5. Search broadly for alternatives only when the declared runtime path is missing or unusable
 
-For products with both Java and Node.js runtime artifacts, the MCP server may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the MCP server may fall back to the Node.js CLI runtime.
+When multiple runtime artifacts are available, runtime selection is an execution
+policy, not a semantic priority. The upstream main application remains the
+semantic center. Runtime differences should be reported as capability or
+compatibility diagnostics.
 
-This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+When an MCP repository bundles upstream runtime artifacts, `runtime/` is the preferred repository directory. The name reflects that these files are execution artifacts used by the MCP adapter, not general vendored source material. Use `vendor/` only when a repository intentionally vendors third-party source or dependency material.
+
+Recommended runtime artifact layout:
+
+```text
+runtime/
+  product-runtime/
+    runnable-artifact
+    source-traceability-artifact
+```
+
+`runtime/` is the installed runtime surface for the MCP adapter. It should
+contain runnable artifacts and, when available, paired source traceability
+artifacts. The MCP server executes only runnable artifacts, but source
+traceability artifacts can keep runtime bundles auditable without requiring the
+full upstream source checkout.
+
+The exact filenames may differ by product, but the artifact role should remain clear in directory names, package metadata, and diagnostics.
 
 ## State and Artifact Principles
 
@@ -392,6 +456,71 @@ Variant-specific differences should be limited to:
 - runtime isolation
 
 If a capability is not safe or practical in one deployment form, the server should report an explicit capability or policy error rather than silently changing behavior.
+
+## Implementation Language Principles
+
+MCP is a protocol, not a language-specific product shape. A miku MCP server may be implemented in TypeScript, Java, or another language when that language is appropriate for the repository and runtime environment.
+
+For miku MCP repositories, Node.js / TypeScript is the standard choice because
+it gives a direct path to local stdio MCP servers, official SDK alignment, JSON
+Schema handling, package metadata, and smoke testing.
+
+Do not add a second MCP server implementation unless a concrete product,
+distribution, or runtime constraint requires it. If that happens, decide the
+language-specific porting rules at that time, using the checked-in MCP contract
+as the stable boundary.
+
+## Recommended Repository Layout
+
+When a miku MCP repository uses a Node.js / TypeScript implementation and keeps room for possible future implementation variants, use a repository layout that separates the shared MCP contract from language-specific server code and runtime artifacts.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  docs/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+      src/
+      test/
+    java/
+      .gitkeep
+  runtime/
+    product-runtime/
+  workplace/
+```
+
+The intended responsibilities are:
+
+- `contract/`
+  - owns shared MCP tool names, input schemas, result shapes, resource URI conventions, prompt names, artifact roles, diagnostics, and error categories
+- `packages/node/`
+  - owns the Node.js / TypeScript MCP server implementation
+  - is usually the first implementation and initial reference implementation
+- `packages/java/`
+  - placeholder only
+- `runtime/`
+  - stores configured or bundled upstream execution artifacts used by the MCP adapters
+- `workplace/`
+  - stores local scratch files, generated outputs, and optional upstream checkouts
+
+The shared MCP contract should not live only as implicit TypeScript code. Keep the contract explicit enough that the MCP surface remains clear even if implementation choices change later.
+
+## Runtime Capability Boundary Principles
+
+When multiple upstream runtime paths exist, the core MCP contract should be limited to operations that are available across the supported runtime paths needed for the product's normal fallback policy.
+
+Runtime-specific operations may be added later as optional, capability-gated extensions, but they should be clearly separated from the core MCP contract. Such operations should:
+
+- be documented as optional extensions
+- report unavailable capability clearly when the selected runtime does not support them
+- avoid changing core tool names, schemas, result shapes, resource URI conventions, artifact roles, or error categories
+- avoid becoming required for the normal local stdio MVP workflow
 
 ## Error Handling Principles
 
@@ -463,13 +592,13 @@ For a first miku MCP server, use this shape.
 For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP operation set.
 
 - `mikuproject.ai_spec`
-- `mikuproject.detect_kind`
+- `mikuproject.ai_detect_kind`
 - `mikuproject.state_from_draft`
-- `mikuproject.project_overview`
-- `mikuproject.task_edit`
-- `mikuproject.phase_detail`
-- `mikuproject.validate_patch`
-- `mikuproject.apply_patch`
+- `mikuproject.ai_export_project_overview`
+- `mikuproject.ai_export_task_edit`
+- `mikuproject.ai_export_phase_detail`
+- `mikuproject.ai_validate_patch`
+- `mikuproject.state_apply_patch`
 - `mikuproject.state_diff`
 - `mikuproject.state_summarize`
 - `mikuproject.export_workbook_json`
@@ -507,9 +636,6 @@ The preferred repository relationship is as follows.
 - `mikuproject`
   - owns the upstream product semantics
   - owns the canonical domain behavior, conversion policy, report policy, and AI-facing product contracts
-- `mikuproject-java`
-  - provides the Java runtime and jar-based execution path when used
-  - keeps Java CLI behavior aligned with the upstream product
 - `mikuproject-skills`
   - provides the Agent Skills workflow design reference
   - records operation maps, state-handling rules, file workflow rules, and agent-facing boundaries
@@ -522,37 +648,53 @@ The preferred repository relationship is as follows.
 
 For development, `mikuproject-mcp` may use local upstream checkouts under `workplace/upstream/`.
 
+When cloning upstream repositories for local reference, clone them into the prescribed `workplace/upstream/` directory. Do not clone upstream repositories into the repository root, `runtime/`, `packages/`, or `contract/`.
+
 Recommended layout:
 
 ```text
 mikuproject-mcp/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+    java/
+  runtime/
+    product-runtime/
   workplace/
     upstream/
       mikuproject/
-      mikuproject-java/
       mikuproject-skills/
 ```
 
-These checkouts are reference material and local development inputs. They should normally remain outside Git tracking except for placeholder files needed to keep the workspace directory shape.
+`contract/` is the shared MCP contract. `packages/node/` is the TypeScript implementation and reference implementation. `packages/java/` is a placeholder only.
+
+Files under `runtime/` are the configured or bundled execution artifacts used by the MCP server. Checkouts under `workplace/upstream/` are reference material and local development inputs. They should normally remain outside Git tracking except for placeholder files needed to keep the workspace directory shape.
+
+Use the following clone destinations:
+
+```text
+workplace/upstream/mikuproject/
+workplace/upstream/mikuproject-skills/
+```
 
 The upstream checkouts should be used to inspect and synchronize the following.
 
 - upstream `mikuproject` CLI contracts and AI-facing specifications
 - upstream `mikuproject` product behavior and artifact roles
-- `mikuproject-java` jar behavior and Java CLI parity
 - `mikuproject-skills` operation map and workflow boundary rules
 - runtime artifact generation and smoke-test expectations
 
-The MCP repository may copy, bundle, or download runtime artifacts according to its own packaging policy, but it should not treat `workplace/upstream/` itself as the installed runtime surface.
+The MCP repository may copy, bundle, or download runtime artifacts into `runtime/` according to its own packaging policy, but it should not treat `workplace/upstream/` itself as the installed runtime surface.
 
 The clean responsibility split is:
 
 ```text
 mikuproject
   -> upstream semantic owner
-
-mikuproject-java
-  -> Java runtime / jar provider
 
 mikuproject-skills
   -> Agent Skills workflow design reference
@@ -565,11 +707,29 @@ The first implementation should borrow heavily from `mikuproject-skills` design 
 
 - operation names and operation grouping
 - `mikuproject_workbook_json` as the practical state boundary
-- Java runtime preference with Node.js runtime fallback
 - distinction between structural workbook `XLSX` and `WBS XLSX` report output
 - distinction between draft, patch, projection, workbook, report, and diagnostics artifacts
 - default local output discipline for state, report, and temporary files
 
-The first implementation should prefer local stdio transport. It should call `mikuproject.jar` or `mikuproject.mjs` through fixed runtime adapter code. It should keep the tool names aligned with the existing `mikuproject-skills` operation map and the Java / Node.js CLI correspondence.
+The first implementation should prefer local stdio transport. It should call
+runtime artifacts through fixed runtime adapter code. It should keep the tool
+names aligned with the existing `mikuproject-skills` operation map and upstream
+CLI correspondence.
+
+The CLI command tree is the naming source for MCP tools:
+
+- `ai spec` becomes `mikuproject.ai_spec`
+- `ai detect-kind` becomes `mikuproject.ai_detect_kind`
+- `state from-draft` becomes `mikuproject.state_from_draft`
+- `ai validate-patch` becomes `mikuproject.ai_validate_patch`
+- `state apply-patch` becomes `mikuproject.state_apply_patch`
+
+For `mikuproject-mcp`, the MCP server implementation is TypeScript. The
+TypeScript version establishes the MCP contract for tools, schemas, result
+shapes, resources, diagnostics, and local workspace behavior.
+
+`packages/java/` remains a placeholder only. Do not predesign another MCP server
+implementation in the current Node server documentation. If a concrete future
+requirement appears, handle that implementation design at that time.
 
 If `mikuproject-mcp` later adds an HTTP server, it should keep the same core tool names. The HTTP server should add session-scoped resources, upload handling, authentication, storage policy, and artifact lifecycle management rather than changing the product operation vocabulary.


### PR DESCRIPTION
## 概要

Miku Software MCP Designを `v20260427` に更新し、mikuシリーズにおけるMCPサーバーの標準実装方針として Node.js / TypeScript を明確化します。

## 変更内容

- `docs/miku-soft-50-mcp-design-v20260426.md` を `docs/miku-soft-50-mcp-design-v20260427.md` へ更新
- MCPサーバーを「薄いプロトコルアダプター」として位置づける設計方針を整理
- local stdio を初期実装ターゲットとし、HTTPサーバーを後続のデプロイ形態として扱う方針を追加
- MCP tool / resource / prompt / runtime / state / error handling / security / repository layout に関する設計原則を拡充
- `mikuproject-mcp` の実装方針として、Node.js / TypeScript を標準とし、`packages/java/` はプレースホルダー扱いであることを明記
- `docs/miku-soft-00-overview-design-v20260427.md` のMCP関連説明を、Node.js / TypeScript MCPサーバー方針に合わせて更新

## 確認事項

- テスト実行: 未実施
- 理由: 変更内容はドキュメント更新のみ