### PR TITLE
Agent Skill の backend policy と Phase C report export 検証を整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Typical things you can ask for:
 
 - This repository does not aim to replace the `mikuproject` browser UI.
 - For advanced workflows, the skill can also work with structured plan data such as workbook JSON.
+- The skill is designed as a workflow layer that can run as `Agent Skill over CLI backend` or `Agent Skill over MCP backend`, depending on the execution policy.
+- The MCP server adapter product is named `mikuproject-mcp`; MCP tools keep the `mikuproject.*` product prefix.
 - If you are evaluating or developing the repository itself, see the documents under [`docs/`](./docs/).
 
 Developer-oriented entry points:
@@ -90,6 +92,8 @@ This project is licensed under the Apache License 2.0. See [`LICENSE`](./LICENSE
 
 - このリポジトリは `mikuproject` のブラウザ UI を置き換えることを目的にはしていません。
 - より高度な運用では、workbook JSON などの構造化された計画データも扱えます。
+- この skill は workflow layer として設計されており、実行 policy に応じて `Agent Skill over CLI backend` または `Agent Skill over MCP backend` として扱えます。
+- MCP server adapter の製品名は `mikuproject-mcp` で、MCP tool は `mikuproject.*` の product prefix を使います。
 - リポジトリ自体の評価や開発を行う場合は [`docs/`](./docs/) 以下の文書を参照してください。
 
 開発者向けの入口:

--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,8 @@
 - 2026-04-14: `tests/mikuproject-bundle-smoke.test.js` を追加し、bundle を一時ディレクトリへ展開した孤立環境でも CLI が起動することを回帰確認に入れた
 - 2026-04-25: `docs/skill-installation.md` に bundle の必須構成として `skills/mikuproject/runtime/mikuproject.jar` と `mikuproject.mjs` を追記した
 - 2026-04-14: `npm test` で 3 files / 3 tests passed を確認し、`npm run build:bundle:zip` で `bundle/mikuproject-skills-20260413.zip` を再生成した
+- 2026-04-29: `workplace/mikuproject-mcp-devel` で `npm install` 後に `npm run build && npm run test` を実行し、27 tests passed を確認した
+- 2026-04-29: root の `npm test` で 3 files / 3 tests passed を確認した
 
 ## 10. 文書化
 
@@ -185,14 +187,18 @@
 
 ### Phase C: Report / Presentation Outputs
 
-- [ ] `WBS XLSX` 出力支援
-- [ ] `SVG` 出力各種の支援
-- [ ] `Markdown` 出力支援
-- [ ] `Mermaid` 出力支援
+- [x] `WBS XLSX` 出力支援
+- [x] `SVG` 出力各種の支援
+- [x] `Markdown` 出力支援
+- [x] `Mermaid` 出力支援
 
 設計メモ:
 
 - [x] `docs/report-export.md` に report / presentation 出力を統合して整理する
+
+検証メモ:
+
+- 2026-04-29: `tests/mikuproject-phase-c-smoke.test.js` を追加し、Node.js / Java runtime の両方で `report wbs-xlsx`、`daily-svg`、`weekly-svg`、`monthly-calendar-svg`、`wbs-markdown`、`mermaid`、`all` の生成を確認するようにした
 
 ### Other Future Candidates
 
@@ -215,49 +221,83 @@ MCP backend を使えるようにする。
 
 ### Backend policy values
 
-- [ ] `cli-only`: 同梱 CLI backend だけを使い、MCP へ自動 fallback しない
-- [ ] `cli-preferred`: まず同梱 CLI backend を使い、許可されている場合だけ MCP へ fallback する
-- [ ] `mcp-only`: MCP backend だけを使い、CLI へ自動 fallback しない
-- [ ] `mcp-preferred`: まず MCP backend を使い、許可されている場合だけ CLI へ fallback する
-- [ ] `handoff-only`: backend 実行を行わず、spec / JSON / 手順を visible handoff として返す
+- [x] `cli-only`: 同梱 CLI backend だけを使い、MCP へ自動 fallback しない
+- [x] `cli-preferred`: まず同梱 CLI backend を使い、許可されている場合だけ MCP へ fallback する
+- [x] `mcp-only`: MCP backend だけを使い、CLI へ自動 fallback しない
+- [x] `mcp-preferred`: まず MCP backend を使い、許可されている場合だけ CLI へ fallback する
+- [x] `handoff-only`: backend 実行を行わず、spec / JSON / 手順を visible handoff として返す
 
 既定値:
 
-- [ ] 明示 policy がない場合の既定を `cli-preferred` として文書化する
-- [ ] `*-only` policy では別 backend に逃げないことを明記する
-- [ ] `*-preferred` policy の場合だけ fallback できることを明記する
-- [ ] ユーザー指示、環境設定、repo 設定、チーム運用ルールの順序関係を整理する
+- [x] 明示 policy がない場合の既定を `cli-preferred` として文書化する
+- [x] `*-only` policy では別 backend に逃げないことを明記する
+- [x] `*-preferred` policy の場合だけ fallback できることを明記する
+- [x] ユーザー指示、環境設定、repo 設定、チーム運用ルールの順序関係を整理する
 
 ### Agent Skill documentation updates
 
-- [ ] `docs/miku-soft-40-agentskills-design-v20260425.md` に execution backend policy を反映する
+- [x] `docs/miku-soft-40-agentskills-design-v20260429.md` に execution backend policy を反映する
   - Agent Skill が workflow layer として残り、実行面は CLI backend / MCP backend / handoff backend を選べることを追記する
   - 既定は `cli-preferred` だが、環境 policy が上位であることを明記する
   - `cli-only` / `mcp-only` の strict policy では別 backend へ自動 fallback しないことを明記する
   - MCP backend は `miku-soft-50` の MCP server layer を利用する形であり、Agent Skill が MCP server の実装責務を持たないことを明記する
-- [ ] `skills/mikuproject/SKILL.md` の Runtime Discipline を backend policy 前提に更新する
-- [ ] `skills/mikuproject/references/runtime/operations-map.md` に CLI backend と MCP backend の対応表を追加する
-- [ ] `skills/mikuproject/references/workflow/active-workflow-rules.md` に backend policy をまたぐ fallback 禁止ルールを追加する
-- [ ] `docs/agent-skill-design.md` に `Agent Skill over CLI backend` と `Agent Skill over MCP backend` の責務分担を追記する
-- [ ] `docs/quickstart.md` に `cli-preferred` 既定と `mcp-only` / `cli-only` の使い分けを追記する
-- [ ] `docs/development.md` に backend policy の保守方針と検証対象を追記する
+- [x] `skills/mikuproject/SKILL.md` の Runtime Discipline を backend policy 前提に更新する
+- [x] `skills/mikuproject/references/runtime/operations-map.md` に CLI backend と MCP backend の対応表を追加する
+- [x] `skills/mikuproject/references/workflow/active-workflow-rules.md` に backend policy をまたぐ fallback 禁止ルールを追加する
+- [x] `docs/agent-skill-design.md` に `Agent Skill over CLI backend` と `Agent Skill over MCP backend` の責務分担を追記する
+- [x] `docs/quickstart.md` に `cli-preferred` 既定と `mcp-only` / `cli-only` の使い分けを追記する
+- [x] `docs/development.md` に backend policy の保守方針と検証対象を追記する
 
 ### MCP backend alignment
 
-- [ ] `workplace/mikuproject-mcp-devel` の MCP tool 名と Agent Skill operation 名の対応を確認する
-- [ ] MCP backend で使う主要 tool を Phase A / Phase B / Phase C に分ける
-- [ ] MCP backend 利用時の state 境界を `mikuproject_workbook_json`、resource URI、server-managed path の関係で整理する
-- [ ] MCP backend 利用時に `mikuproject://state/current` などの resource URI をどこまで Agent Skill 文書に出すか決める
-- [ ] direct CLI の file path 中心の結果と MCP の resource / operationId 中心の結果を同じ artifact role で説明できるようにする
+- [x] `workplace/mikuproject-mcp-devel` の MCP tool 名と Agent Skill operation 名の対応を確認する
+- [x] MCP backend で使う主要 tool を Phase A / Phase B / Phase C に分ける
+- [x] MCP backend 利用時の state 境界を `mikuproject_workbook_json`、resource URI、server-managed path の関係で整理する
+- [x] MCP backend 利用時に `mikuproject://state/current` などの resource URI をどこまで Agent Skill 文書に出すか決める
+- [x] direct CLI の file path 中心の結果と MCP の resource / operationId 中心の結果を同じ artifact role で説明できるようにする
 
 ### Implementation candidates
 
-- [ ] backend policy を会話上の明示指示として解釈するルールを作る
-- [ ] backend policy を設定ファイルで固定できるか検討する
-- [ ] MCP tools が利用可能な環境では、CLI コマンド例だけでなく MCP tool 名も参照できるようにする
-- [ ] `mcp-only` のときに CLI runtime artifact を探索しないことを明文化する
-- [ ] `cli-only` のときに MCP tool 探索へ進まないことを明文化する
-- [ ] fallback した場合は、どの backend からどの backend へ移ったかを concise diagnostics として返す
+- [x] backend policy を会話上の明示指示として解釈するルールを作る
+- [x] backend policy を設定ファイルで固定できるか検討する
+- [x] MCP tools が利用可能な環境では、CLI コマンド例だけでなく MCP tool 名も参照できるようにする
+- [x] `mcp-only` のときに CLI runtime artifact を探索しないことを明文化する
+- [x] `cli-only` のときに MCP tool 探索へ進まないことを明文化する
+- [x] fallback した場合は、どの backend からどの backend へ移ったかを concise diagnostics として返す
+- [x] skill-local 設定ファイル `skills/mikuproject/config/backend-policy.json` を追加する
+- [x] 設定ファイルをユーザー明示指示と実行環境 policy より下位に置くことを文書化する
+
+### Next implementation handoff
+
+次セッションでの推奨順:
+
+1. まず今回の文書同期差分を確認して commit する
+2. 設定ファイル固定は、会話上の明示指示ルールが固まってから検討する
+3. smoke test は、実際の backend selector 実装または検証可能なルール表現ができてから追加する
+
+現時点の前提:
+
+- Agent Skill は workflow layer として残す
+- 既定 policy は `cli-preferred`
+- `cli-only` / `mcp-only` / `handoff-only` は strict policy として扱う
+- MCP backend の参照 contract は `workplace/mikuproject-mcp-devel` の `mikuproject-mcp`
+- MCP tool 名は `mikuproject.ai_spec` のようなドット区切り
+- MCP server product / repo / adapter 名は `mikuproject-mcp`
+- MCP client configuration の server key は短く `mikuproject` でよい
+- custom `outputPath` の成果物には固定 `mikuproject://` resource URI を付けない
+- 会話上の明示 policy は exact value (`cli-only` / `cli-preferred` / `mcp-only` / `mcp-preferred` / `handoff-only`) を含む場合に解釈する
+
+検証済み:
+
+- 2026-04-29: `workplace/mikuproject-mcp-devel` で `npm install` 後に `npm run build && npm run test` が通過した
+- 2026-04-29: root の `npm test` が通過した
+- 2026-04-29: `skills/mikuproject/config/backend-policy.json` を追加し、bundle 同梱と policy contract を `tests/mikuproject-backend-policy-config.test.js` で確認するようにした
+
+`mikuproject-mcp` 側への申し送り:
+
+- 実体 repo が別ディレクトリにあるため、この repo の `workplace/mikuproject-mcp-devel` でのテスト修正は本体には未反映
+- issue 候補: `packages/node/src/test/serverSmoke.test.ts` の workspace root assertion が checkout 名 `mikuproject-mcp` 固定になっており、`mikuproject-mcp-devel` では落ちる
+- 推奨修正例: `assert.match(workspace.root, /mikuproject-mcp(?:-devel)?\/workplace$/);`
 
 ### Tests and smoke checks
 

--- a/docs/agent-skill-design.md
+++ b/docs/agent-skill-design.md
@@ -121,6 +121,131 @@ MVP では、次の upstream runtime artifact を主要入口とする。
 - `node skills/mikuproject/runtime/mikuproject.mjs state apply-patch`
 - `node skills/mikuproject/runtime/mikuproject.mjs state diff`
 
+## Execution Backend Policy
+
+Agent Skill は workflow layer として残し、実行面だけを backend policy で切り替える。
+
+既定値は `cli-preferred` とする。
+ただし、ユーザー指示、実行環境の制約、repo 設定がある場合はそれを優先する。
+
+policy 値:
+
+- `cli-only`: CLI backend だけを使い、MCP へ自動 fallback しない
+- `cli-preferred`: CLI backend を先に使い、許可されている場合だけ MCP へ fallback する
+- `mcp-only`: MCP backend だけを使い、CLI へ自動 fallback しない
+- `mcp-preferred`: MCP backend を先に使い、許可されている場合だけ CLI へ fallback する
+- `handoff-only`: backend 実行を行わず、spec / JSON / 手順を visible handoff として返す
+
+`cli-only` と `mcp-only` は strict policy として扱う。
+選ばれた backend が使えない場合は、別 backend に逃げず、実行経路エラーとして返す。
+
+fallback が許可されていて実際に発生した場合は、どの backend からどの backend へ移ったか、
+および理由を短く返す。
+
+会話上の明示 policy は、現在のユーザー依頼に `cli-only`、`cli-preferred`、
+`mcp-only`、`mcp-preferred`、`handoff-only` のいずれかが exact value として
+含まれる場合に解釈する。`で`、`として`、`固定`、`only`、`preferred`、
+`fallbackなし` のような周辺語は許容する。
+
+例:
+
+- `mikuproject、mcp-only で要約して`
+- `mikuproject cli-only 固定で WBS XLSX を出して`
+- `mikuproject handoff-only として spec を出して`
+
+同一依頼内に複数の policy 値が出て、どれかが明確に否定されているわけではない場合は、
+実行前にどの policy を使うか確認する。`MCP でも使える?` のような backend 名だけの質問は
+capability question として扱い、`mcp-only` の strict policy とは解釈しない。
+
+## Agent Skill over CLI backend
+
+CLI backend を使う場合でも、Agent Skill の責務は CLI wrapper そのものではない。
+
+Agent Skill 側の責務:
+
+- `mikuproject` の activation boundary を守る
+- `spec` / `draft` / `patch` / `workbook` などの操作単位を選ぶ
+- `project_draft_view`、`Patch JSON`、`mikuproject_workbook_json` の artifact role を守る
+- Java CLI と Node.js CLI のどちらを使うかを runtime policy に従って決める
+- 中間ファイルと出力ファイルの置き場所を整理する
+- warning / error / diff summary を利用者に分かる形で返す
+
+CLI backend 側の責務:
+
+- upstream runtime artifact として product operation を実行する
+- import / export / validate / apply / report などの変換実体を持つ
+- upstream product の diagnostics を返す
+
+CLI backend を使っても、skill 側で upstream 変換ロジックを再実装しない。
+
+## Agent Skill over MCP backend
+
+MCP backend を使う場合も、Agent Skill は MCP server にはならない。
+
+Agent Skill 側の責務:
+
+- CLI backend 利用時と同じ operation vocabulary を維持する
+- Agent Skill operation と MCP tool / resource の対応を選ぶ
+- `mcp-only` / `mcp-preferred` / fallback policy を守る
+- MCP tool の結果を、skill の artifact role と response shape に合わせて説明する
+- MCP resource URI、server-managed path、workbook JSON の境界を混同しない
+
+MCP backend 側の責務:
+
+- product-specific MCP server として tool / resource / prompt contract を提供する
+- tool input schema と result schema を管理する
+- state や generated artifact を MCP resource として公開する
+- upstream runtime artifact または public API を呼び出す
+
+`mikuproject-skills` 側では、MCP tool 名や resource URI contract を勝手に再定義しない。
+MCP backend は `mikuproject-mcp` などの MCP server layer によって提供される前提とする。
+
+### 現行 `mikuproject-mcp` contract との対応
+
+現行の `mikuproject-mcp` は、MCP tool 名を upstream CLI command tree から導出している。
+
+例:
+
+- `ai spec` -> `mikuproject.ai_spec`
+- `ai detect-kind` -> `mikuproject.ai_detect_kind`
+- `state from-draft` -> `mikuproject.state_from_draft`
+- `ai export project-overview` -> `mikuproject.ai_export_project_overview`
+- `state apply-patch` -> `mikuproject.state_apply_patch`
+- `export workbook-json` -> `mikuproject.export_workbook_json`
+
+Agent Skill operation との対応は次の考え方で扱う。
+
+- Agent Skill の `spec` は MCP tool `mikuproject.ai_spec` に対応する
+- Agent Skill の `draft` は MCP tool `mikuproject.state_from_draft` に対応する
+- Agent Skill の `patch-validate` は MCP tool `mikuproject.ai_validate_patch` に対応する
+- Agent Skill の `patch` は MCP tool `mikuproject.state_apply_patch` に対応する
+- Agent Skill の `workbook` / `workbook-export` は MCP tool `mikuproject.export_workbook_json` に対応する
+- Agent Skill の report 系のうち、現行 MCP backend では `wbs-markdown` と `mermaid` が対応済みである
+
+現行 `mikuproject-mcp` の主な resource URI は次の通り。
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://export/workbook-json`
+- `mikuproject://export/project-xml`
+- `mikuproject://export/project-xlsx`
+- `mikuproject://projection/{name}`
+- `mikuproject://report/wbs-markdown`
+- `mikuproject://report/mermaid`
+- `mikuproject://summary/{operationId}`
+- `mikuproject://diagnostics/{operationId}`
+
+state 境界は次のように整理する。
+
+- Agent Skill の会話境界 state は引き続き `mikuproject_workbook_json`
+- MCP backend の現在状態は `mikuproject://state/current` として参照できる
+- MCP server-managed path に書かれた artifact だけが固定 `mikuproject://` URI を持つ
+- custom `outputPath` へ出した artifact は、固定 resource URI ではなく file path artifact として扱う
+- operation summary と diagnostics は `operationId` で `mikuproject://summary/{operationId}` / `mikuproject://diagnostics/{operationId}` に紐づける
+
+この対応を使うことで、CLI backend の file path 中心の結果と、MCP backend の resource URI / `operationId` 中心の結果を、同じ artifact role で説明できる。
+
 ## 操作単位
 
 MVP では、Skill の責務を 4 つの操作単位として定義する。

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,6 +99,97 @@ npm run update:runtime
 MIKUPROJECT_REF=main MIKUPROJECT_JAVA_REF=main npm run update:runtime
 ```
 
+## Execution backend policy の保守方針
+
+`mikuproject-skills` は Agent Skill workflow layer として保守します。
+実行面は backend policy によって CLI backend、MCP backend、handoff backend を選べるようにします。
+
+既定値:
+
+- 明示 policy がない場合は `cli-preferred`
+
+skill-local 設定:
+
+- `skills/mikuproject/config/backend-policy.json`
+- bundle に同梱し、既定 policy、許可 policy、strict policy、fallback 可否を機械可読に記録する
+- 優先順位は `user-request`、`environment-policy`、`skill-config`、`repository-default`
+- ユーザー明示指示や実行環境 policy と衝突する場合、設定ファイル側を優先しない
+
+policy 値:
+
+- `cli-only`: CLI backend だけを使い、MCP fallback しない
+- `cli-preferred`: CLI backend を先に使い、許可されている場合だけ MCP fallback する
+- `mcp-only`: MCP backend だけを使い、CLI fallback しない
+- `mcp-preferred`: MCP backend を先に使い、許可されている場合だけ CLI fallback する
+- `handoff-only`: backend 実行をせず、visible handoff だけを返す
+
+保守時の注意:
+
+- `cli-only` と `mcp-only` は strict policy として扱う
+- strict policy では別 backend の探索や自動 fallback を追加しない
+- `handoff-only` では CLI command も MCP tool も呼ばない
+- fallback を実装または変更した場合は、source backend、target backend、理由を diagnostics に残す
+- MCP backend の tool / resource contract は MCP server layer 側に置き、Agent Skill 側で再定義しない
+- CLI backend と MCP backend で artifact role と operation vocabulary を変えない
+
+検証対象:
+
+- `cli-only` で MCP fallback しないこと
+- `mcp-only` で CLI fallback しないこと
+- `cli-preferred` で CLI が使えない場合、許可された MCP fallback だけが起きること
+- `mcp-preferred` で MCP が使えない場合、許可された CLI fallback だけが起きること
+- `handoff-only` で backend 実行が起きないこと
+- import / export / report 系でも同じ backend policy が適用されること
+- fallback diagnostics が簡潔に返ること
+
+## 現行 MCP backend 参照
+
+MCP backend の参照実装は `workplace/mikuproject-mcp-devel` の
+`mikuproject-mcp` です。
+
+`mikuproject-mcp` 側で確認する contract:
+
+- `contract/runtime-cli-mapping.md`
+- `contract/resources/resource-uris.md`
+- `contract/results/artifact-roles.md`
+- `contract/tools/*.schema.json`
+
+現行 tool 名は upstream CLI command tree から導出されたドット区切りです。
+
+例:
+
+- `mikuproject.ai_spec`
+- `mikuproject.ai_detect_kind`
+- `mikuproject.state_from_draft`
+- `mikuproject.ai_export_project_overview`
+- `mikuproject.ai_export_task_edit`
+- `mikuproject.ai_export_phase_detail`
+- `mikuproject.ai_validate_patch`
+- `mikuproject.state_apply_patch`
+- `mikuproject.state_diff`
+- `mikuproject.state_summarize`
+- `mikuproject.export_workbook_json`
+- `mikuproject.export_xml`
+- `mikuproject.export_xlsx`
+- `mikuproject.import_xlsx`
+- `mikuproject.report_wbs_markdown`
+- `mikuproject.report_mermaid`
+
+Agent Skill 側の docs で MCP tool 名を書く場合は、このドット区切り名を使います。
+underscore-only の `mikuproject_ai_spec` のような名前に置き換えません。
+
+現行 resource URI の代表例:
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://export/workbook-json`
+- `mikuproject://projection/{name}`
+- `mikuproject://report/wbs-markdown`
+- `mikuproject://report/mermaid`
+- `mikuproject://summary/{operationId}`
+- `mikuproject://diagnostics/{operationId}`
+
 ## テスト
 
 root で `vitest` を有効化しています。

--- a/docs/miku-soft-40-agentskills-design-v20260429.md
+++ b/docs/miku-soft-40-agentskills-design-v20260429.md
@@ -35,7 +35,7 @@ Use the shared design documents together as follows.
   - describes Java runtime versions when they exist
 - `docs/miku-soft-30-straight-conversion-v20260425.md`
   - describes how Java versions are created from upstream main applications
-- `docs/miku-soft-40-agentskills-design-v20260425.md`
+- `docs/miku-soft-40-agentskills-design-v20260429.md`
   - describes how Agent Skills versions should expose miku workflows to AI agents
 
 This document separates the following levels.
@@ -140,6 +140,7 @@ miku Agent Skills emphasize the following cross-cutting principles.
 6. Distinguish canonical source, conversation state, primary output, reports, and temporary handoff data.
 7. Use small projections, patches, validation, and diffs for AI-assisted edits where practical.
 8. Make installation, bundling, smoke testing, and upstream synchronization explainable.
+9. Keep workflow guidance separate from execution backend selection so CLI, MCP, and handoff execution can follow explicit policy.
 
 ### Basic Philosophy of Agent Skills
 
@@ -173,6 +174,7 @@ Agent Skills use the following principles as defaults.
 - Treat the Node.js CLI runtime artifact as a single JavaScript file
 - Use bundled upstream runtime artifacts when local, reproducible execution and bundling need them
 - Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Allow execution backend policy to choose CLI, MCP, or handoff behavior without changing the skill name or workflow vocabulary
 - Package distributable bundles with scripts that can be tested
 - Keep repository-level README user-facing and developer details under `docs/`
 - Use `workplace/` for local scratch data, upstream checks, generated outputs, and verification files
@@ -219,6 +221,36 @@ Do not create a separate skill product line only because an additional runtime p
 When both Java CLI and Node.js CLI runtime artifacts are bundled, the skill may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the skill may fall back to the Node.js CLI runtime.
 
 This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
+### Execution Backend Policy Principles
+
+Agent Skills should remain the workflow layer even when the execution backend changes.
+
+The skill owns activation rules, operation selection, artifact roles, file placement guidance, diagnostics policy, and handoff expectations. The execution backend owns how an operation is actually carried out in a particular environment.
+
+Common backend categories are:
+
+- CLI backend: run bundled or configured upstream CLI artifacts, usually through Java or Node.js commands
+- MCP backend: call a product-specific MCP server that exposes aligned tools and resources
+- handoff backend: do not execute the product operation directly; return the spec, structured JSON, prompt, or step-by-step handoff material visibly
+
+The default policy for mature miku Agent Skills should be `cli-preferred`: try the declared local CLI backend first, and fall back to MCP only when that fallback is allowed by the active environment and repository policy.
+
+Supported policy values should be interpreted as follows.
+
+- `cli-only`: use only the CLI backend; do not inspect or call MCP as an automatic fallback
+- `cli-preferred`: use CLI first; use MCP only when CLI is unavailable or unsuitable and fallback is allowed
+- `mcp-only`: use only the MCP backend; do not inspect or run CLI artifacts as an automatic fallback
+- `mcp-preferred`: use MCP first; use CLI only when MCP is unavailable or unsuitable and fallback is allowed
+- `handoff-only`: do not execute backend operations; provide visible handoff material and instructions
+
+Execution backend policy is subordinate to the user's explicit instruction and the active environment policy. If an environment disallows CLI execution, a skill must not run CLI commands merely because `cli-preferred` is the repository default. If an environment disallows MCP access, a skill must not call MCP tools merely because CLI failed.
+
+Strict policies are intentionally strict. Under `cli-only` or `mcp-only`, failure of the selected backend should be reported as a hard execution-path error instead of silently switching to another backend. Under `handoff-only`, backend execution should not occur even when CLI or MCP is available.
+
+When fallback is allowed and happens, diagnostics should state the source backend, target backend, and concise reason. For example, a result may say that CLI was unavailable and execution continued through MCP, or that MCP lacked a required tool and execution continued through CLI.
+
+An MCP backend should use the MCP server layer described by the miku MCP design documents. The Agent Skill should not become the MCP server implementation and should not redefine MCP tool names, resource roles, or protocol contracts locally. It should describe how its operation vocabulary maps to the MCP tools and resources exposed by the product-specific MCP server.
 
 ### AI-Facing Spec Retrieval Principles
 
@@ -438,6 +470,7 @@ Test coverage should include:
 - skill smoke tests
 - upstream runtime availability checks
 - runtime selection checks, including Java CLI available, Java CLI unavailable with Node.js fallback, unsupported Java CLI operation with Node.js fallback, and all runtimes missing as a hard error
+- execution backend policy checks, including strict `cli-only`, strict `mcp-only`, preferred fallback behavior, and `handoff-only` no-execution behavior when the repository supports those modes
 - representative import / export operations
 - draft / patch / validate / apply operations where applicable
 - diagnostics and hard-error behavior
@@ -636,6 +669,8 @@ Important design points:
 - report outputs such as `WBS XLSX`, `SVG`, `Markdown`, `Mermaid`, and ZIP are derived outputs
 - AI JSON spec retrieval is exposed through upstream core API functions and the `mikuproject ai spec` CLI path, so the skill should prefer those contracts over file search
 - declared `mikuproject` runtime artifacts are checked before broad repository exploration
+- execution backend policy defaults to `cli-preferred`, while still allowing `cli-only`, `mcp-only`, `mcp-preferred`, and `handoff-only` when the user, environment, or repository configuration requires them
+- MCP backend support should use the `mikuproject-mcp` server layer and aligned MCP tools; `mikuproject-skills` remains the Agent Skill workflow layer, not the MCP server implementation
 - the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.mjs`
 - the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.jar`
 

--- a/docs/miku-soft-50-mcp-design-v20260427.md
+++ b/docs/miku-soft-50-mcp-design-v20260427.md
@@ -39,7 +39,7 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260425.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-40-agentskills-design-v20260425.md`
+- `docs/miku-soft-40-agentskills-design-v20260429.md`
   - describes how Agent Skills versions expose miku workflows to AI agents
 - `docs/miku-soft-50-mcp-design-v20260427.md`
   - describes how MCP server versions should expose miku workflows to MCP clients
@@ -327,7 +327,12 @@ Examples:
 - `mikuproject.ai_validate_patch`
 - `mikuproject.state_apply_patch`
 - `mikuproject.state_diff`
+- `mikuproject.state_summarize`
 - `mikuproject.export_workbook_json`
+- `mikuproject.export_xml`
+- `mikuproject.export_xlsx`
+- `mikuproject.import_xlsx`
+- `mikuproject.report_wbs_markdown`
 - `mikuproject.report_mermaid`
 
 Tool input should use JSON Schema. Tool results should return structured content when practical. For compatibility with clients that primarily display text, structured results may also be serialized into a text content block.
@@ -602,8 +607,16 @@ For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP ope
 - `mikuproject.state_diff`
 - `mikuproject.state_summarize`
 - `mikuproject.export_workbook_json`
+- `mikuproject.export_xml`
+- `mikuproject.export_xlsx`
+- `mikuproject.import_xlsx`
+- `mikuproject.report_wbs_markdown`
+- `mikuproject.report_mermaid`
 
-File import/export and report generation can be added after the core state workflow is stable.
+The current first version includes core state workflow tools plus a small file
+import/export and report set. Additional CLI operations such as XML import,
+merge imports, WBS XLSX report export, SVG report export, and full report bundle
+export can remain later capability-gated extensions.
 
 ## Out of Scope for the First Version
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,43 @@
 4. `npm test`
 5. Codex との会話で `mikuproject` skill を使う
 
+## Execution backend policy
+
+通常は `cli-preferred` として扱います。
+
+これは、まず同梱 CLI backend を使い、CLI が使えない場合だけ、許可されていれば MCP backend へ fallback する方針です。
+
+skill bundle には `skills/mikuproject/config/backend-policy.json` が含まれます。
+このファイルは skill 側の既定 policy と許可値を記録するためのものです。
+ユーザーの明示指示と実行環境 policy が優先で、設定ファイルはそれらより下位です。
+
+主な使い分け:
+
+- `cli-preferred`: 既定。ローカル CLI 実行が許可されている通常環境向け
+- `cli-only`: CLI 実行だけを許可し、MCP fallback を禁止したい環境向け
+- `mcp-only`: CLI 実行を禁止し、承認済み MCP server だけを使いたい環境向け
+- `mcp-preferred`: MCP を先に使い、許可されている場合だけ CLI へ fallback したい環境向け
+- `handoff-only`: CLI も MCP も実行せず、spec / JSON / 手順だけを受け渡したい環境向け
+
+`cli-only` と `mcp-only` は strict policy です。
+選んだ backend が使えない場合、別 backend へ自動 fallback せず、実行経路エラーとして扱います。
+
+MCP backend を使う場合の server product 名は `mikuproject-mcp` です。
+MCP client 設定上の server key は短く `mikuproject` としてよいですが、repo / package / server adapter の名称は `mikuproject-mcp` として扱います。
+
+現行 `mikuproject-mcp` の tool 名は `mikuproject.ai_spec`、`mikuproject.state_from_draft`、`mikuproject.state_apply_patch` のようなドット区切りです。
+resource URI は `mikuproject://state/current`、`mikuproject://summary/{operationId}` などを使います。
+
+会話で明示する場合は、依頼に含めます。
+
+```text
+mikuproject、mcp-only でこの workbook を要約して
+```
+
+```text
+mikuproject、cli-only で WBS XLSX を出力して
+```
+
 ## 事前準備
 
 ### 1. workspace を揃える

--- a/skills/mikuproject/SKILL.md
+++ b/skills/mikuproject/SKILL.md
@@ -40,7 +40,35 @@ Use these before falling back to direct file reads or UI-oriented flows.
 
 For explicit `mikuproject` import/export or report requests, first check the bundled `mikuproject` runtime artifacts before broad workspace exploration or generic tool discovery.
 
-Use this order:
+Unless the user, environment, or skill configuration states another execution backend policy, use `cli-preferred`.
+The skill-local configuration file is `skills/mikuproject/config/backend-policy.json`.
+It records the repository default and allowed policy values for installed bundles.
+Treat it as lower priority than explicit user instructions and environment policy.
+
+Backend policy values:
+
+- `cli-only`: use only the bundled CLI backend; do not inspect or call MCP tools as fallback
+- `cli-preferred`: use the bundled CLI backend first; use MCP only when CLI is unavailable or unsuitable and MCP fallback is allowed
+- `mcp-only`: use only the MCP backend; do not inspect or run CLI artifacts as fallback
+- `mcp-preferred`: use MCP first; use CLI only when MCP is unavailable or unsuitable and CLI fallback is allowed
+- `handoff-only`: do not execute backend operations; return visible spec, JSON, artifact instructions, or handoff steps
+
+Interpret an explicit backend policy in the user's current request when it uses
+one of the exact policy values above, with or without simple Japanese particles
+or wording such as `で`, `として`, `固定`, `only`, `preferred`, or `fallbackなし`.
+Examples:
+
+- `mikuproject、mcp-only で要約して`
+- `mikuproject cli-only 固定で WBS XLSX を出して`
+- `mikuproject handoff-only として spec を出して`
+
+The latest explicit user policy in the active request wins over the skill
+configuration default. Do not infer a strict policy from backend names alone; `MCP でも使える?`
+is a capability question, not `mcp-only`. If multiple policy values appear in
+the same request, stop and ask which policy to use unless one is clearly being
+negated.
+
+For `cli-only` and `cli-preferred`, use this CLI runtime order:
 
 1. read this `SKILL.md`
 2. check `skills/mikuproject/runtime/mikuproject.jar` and `skills/mikuproject/runtime/mikuproject.mjs` first
@@ -53,6 +81,10 @@ For this repository:
 - use `skills/mikuproject/runtime/mikuproject.mjs` when the Java runtime is missing or does not support the requested operation
 - do not search broadly through the workspace before checking the bundled runtime artifacts
 - do not conclude that runtime dependencies are missing until the bundled skill-local runtime path has also been checked when applicable
+- in `mcp-only`, do not probe CLI runtime artifacts just to see whether CLI fallback is possible
+- in `cli-only`, do not probe MCP tools just to see whether MCP fallback is possible
+- in `handoff-only`, do not run CLI commands or MCP tools
+- when allowed fallback happens, report the source backend, target backend, and concise reason
 
 ## Error Handling
 

--- a/skills/mikuproject/config/backend-policy.json
+++ b/skills/mikuproject/config/backend-policy.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "default_policy": "cli-preferred",
+  "allowed_policies": [
+    "cli-only",
+    "cli-preferred",
+    "mcp-only",
+    "mcp-preferred",
+    "handoff-only"
+  ],
+  "strict_policies": [
+    "cli-only",
+    "mcp-only",
+    "handoff-only"
+  ],
+  "precedence": [
+    "user-request",
+    "environment-policy",
+    "skill-config",
+    "repository-default"
+  ],
+  "fallback_allowed": {
+    "cli-only": false,
+    "cli-preferred": true,
+    "mcp-only": false,
+    "mcp-preferred": true,
+    "handoff-only": false
+  }
+}

--- a/skills/mikuproject/references/runtime/operations-map.md
+++ b/skills/mikuproject/references/runtime/operations-map.md
@@ -61,6 +61,98 @@ Use the runtime that supports the requested operation:
 
 Use the upstream CLI runtime artifacts before falling back to direct file reads or UI-oriented flows.
 
+## Backend Operation Correspondence
+
+Use this table when an execution backend policy needs CLI backend / MCP backend
+selection. The Agent Skill operation name remains stable even when the backend
+changes.
+
+MCP backend phase grouping:
+
+- Phase A: AI/state workflow tools used for spec, draft, projections, patch validation, patch apply, diff, summarize, and workbook JSON export
+- Phase B: primary file import/export tools for structural workbook XLSX and MS Project XML export
+- Phase C: report/presentation tools, currently WBS Markdown and Mermaid in the MCP backend
+
+Current `mikuproject-mcp` does not expose every CLI report or merge operation.
+Under `mcp-only`, missing MCP tools remain unavailable rather than falling back
+to CLI.
+
+| Agent Skill operation | CLI backend command family | MCP backend tool | Notes |
+| --- | --- | --- | --- |
+| `spec` | `ai spec` | `mikuproject.ai_spec` | Phase A. Same AI spec role. |
+| `draft` | `state from-draft` | `mikuproject.state_from_draft` | Phase A. Converts `project_draft_view` to workbook state. |
+| `patch` | `state apply-patch` | `mikuproject.state_apply_patch` | Phase A. Requires base workbook state. |
+| `workbook` / `workbook-export` | `export workbook-json` | `mikuproject.export_workbook_json` | Phase A. Exports or normalizes workbook JSON. |
+| `project-overview` | `ai export project-overview` | `mikuproject.ai_export_project_overview` | Phase A. AI projection for existing-plan entry. |
+| `task-edit` | `ai export task-edit` | `mikuproject.ai_export_task_edit` | Phase A. AI projection for task-level editing. |
+| `phase-detail` | `ai export phase-detail` | `mikuproject.ai_export_phase_detail` | Phase A. AI projection for phase-level editing. |
+| `patch-validate` | `ai validate-patch` | `mikuproject.ai_validate_patch` | Phase A. Validates patch against workbook state. |
+| `state-diff` | `state diff` | `mikuproject.state_diff` | Phase A. Compares before / after workbook states. |
+| `state-summarize` | `state summarize` | `mikuproject.state_summarize` | Phase A. Summarizes workbook state. |
+| `detect-kind` | `ai detect-kind` | `mikuproject.ai_detect_kind` | Phase A. Detects product document kind. |
+| `xml-export` | `export xml` | `mikuproject.export_xml` | Phase B. Exports MS Project XML. |
+| `xml-import` | `import xml` when supported by CLI | Not currently exposed | Phase B gap. Keep as CLI or handoff until MCP parity exists. |
+| `xlsx-import` | `import xlsx` | `mikuproject.import_xlsx` | Phase B. Imports structural workbook XLSX. |
+| `xlsx-export` | `export xlsx` | `mikuproject.export_xlsx` | Phase B. Exports structural workbook XLSX. |
+| `xlsx-merge-import` | `merge xlsx` | Not currently exposed | Phase B gap. Keep as CLI or handoff until MCP parity exists. |
+| `workbook-import` | `state import` | Not currently exposed | Phase B gap. Keep as CLI or handoff until MCP parity exists. |
+| `workbook-merge-import` | `state merge` | Not currently exposed | Phase B gap. Keep as CLI or handoff until MCP parity exists. |
+| `wbs-markdown-export` | `report wbs-markdown` | `mikuproject.report_wbs_markdown` | Phase C. Human-facing Markdown report. |
+| `mermaid-export` | `report mermaid` | `mikuproject.report_mermaid` | Phase C. Mermaid gantt text. |
+| `wbs-xlsx-export` | `report wbs-xlsx` | Not currently exposed | Phase C gap. Keep as CLI or handoff until MCP parity exists. |
+| `daily-svg-export` | `report daily-svg` | Not currently exposed | Phase C gap. Keep as CLI or handoff until MCP parity exists. |
+| `weekly-svg-export` | `report weekly-svg` | Not currently exposed | Phase C gap. Keep as CLI or handoff until MCP parity exists. |
+| `monthly-calendar-svg-export` | `report monthly-calendar-svg` | Not currently exposed | Phase C gap. Keep as CLI or handoff until MCP parity exists. |
+| `all-report-export` | `report all` | Not currently exposed | Phase C gap. Keep as CLI or handoff until MCP parity exists. |
+
+Under `cli-only`, use only the CLI backend column. Under `mcp-only`, use only
+the MCP backend column and fail if the operation is not exposed there. Under a
+preferred policy, switch backend only when fallback is allowed and report the
+reason.
+
+The current `mikuproject-mcp` contract uses dot-separated MCP tool names derived
+from the upstream CLI command tree:
+
+- `ai spec` -> `mikuproject.ai_spec`
+- `state from-draft` -> `mikuproject.state_from_draft`
+- `export workbook-json` -> `mikuproject.export_workbook_json`
+
+Do not rewrite these as underscore-only names in Agent Skill documentation.
+
+## MCP Resource and Artifact Roles
+
+The current `mikuproject-mcp` contract uses these common resource URI roles:
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://export/workbook-json`
+- `mikuproject://export/project-xml`
+- `mikuproject://export/project-xlsx`
+- `mikuproject://projection/{name}`
+- `mikuproject://report/wbs-markdown`
+- `mikuproject://report/mermaid`
+- `mikuproject://summary/{operationId}`
+- `mikuproject://diagnostics/{operationId}`
+
+Use these URIs only when the MCP server writes to the server-managed path backing
+that URI. If a tool receives a custom `outputPath`, treat the result as a file
+path artifact rather than pretending it has a fixed `mikuproject://` URI.
+
+Important artifact roles shared with `mikuproject-mcp` include:
+
+- `ai_spec`
+- `draft_document`
+- `patch_document`
+- `projection`
+- `workbook_state`
+- `mikuproject_workbook_json`
+- `ms_project_xml`
+- `xlsx_workbook`
+- `report_output`
+- `operation_summary`
+- `diagnostics_log`
+
 ## Java / Node.js CLI Correspondence
 
 The Java and Node.js runtime CLIs now use the same grouped command shape for

--- a/skills/mikuproject/references/workflow/active-workflow-rules.md
+++ b/skills/mikuproject/references/workflow/active-workflow-rules.md
@@ -18,6 +18,24 @@ Use this reference when the skill is already active and you need follow-up handl
 - do not ask the user to manually pass generated JSON back into the same active skill flow
 - do not answer a WBS request with only a plain Markdown table when `mikuproject` can handle it cleanly
 
+## Backend Policy Discipline
+
+- default to `cli-preferred` when no user, environment, or skill configuration policy says otherwise
+- use `skills/mikuproject/config/backend-policy.json` as the skill-local policy configuration in installed bundles
+- treat skill configuration as lower priority than explicit user instructions and environment policy
+- treat exact policy values in the current user request as an explicit backend policy: `cli-only`, `cli-preferred`, `mcp-only`, `mcp-preferred`, or `handoff-only`
+- accept simple surrounding wording such as `で`, `として`, `固定`, `only`, `preferred`, or `fallbackなし` when the policy value itself is exact
+- the latest explicit user policy in the active request wins over the repository default
+- do not infer a strict policy from backend names alone; `MCP でも使える?` is a capability question, not `mcp-only`
+- if multiple policy values appear in the same request and one is not clearly negated, ask which policy to use before executing
+- under `cli-only`, do not inspect or call MCP tools as an automatic fallback
+- under `mcp-only`, do not inspect or run CLI runtime artifacts as an automatic fallback
+- under `handoff-only`, do not run CLI commands or MCP tools
+- under `cli-preferred` or `mcp-preferred`, fallback only when the active policy and environment allow it
+- if fallback happens, report which backend failed, which backend was used, and the concise reason
+- if a strict backend policy blocks the only available implementation, stop with a hard execution-path error instead of silently switching backend
+- do not use backend fallback to change artifact roles, operation names, or the workbook-oriented flow
+
 ## Draft vs Patch
 
 - new WBS drafting: `project_draft_view`

--- a/tests/mikuproject-backend-policy-config.test.js
+++ b/tests/mikuproject-backend-policy-config.test.js
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const policyConfigPath = path.resolve(
+  ROOT,
+  "skills/mikuproject/config/backend-policy.json"
+);
+
+const expectedPolicies = [
+  "cli-only",
+  "cli-preferred",
+  "mcp-only",
+  "mcp-preferred",
+  "handoff-only"
+];
+
+describe("mikuproject backend policy config", () => {
+  it("defines the supported policy contract", () => {
+    const config = JSON.parse(fs.readFileSync(policyConfigPath, "utf8"));
+
+    expect(config.schema_version).toBe(1);
+    expect(config.default_policy).toBe("cli-preferred");
+    expect(config.allowed_policies).toEqual(expectedPolicies);
+    expect(config.strict_policies).toEqual([
+      "cli-only",
+      "mcp-only",
+      "handoff-only"
+    ]);
+    expect(config.precedence).toEqual([
+      "user-request",
+      "environment-policy",
+      "skill-config",
+      "repository-default"
+    ]);
+    expect(config.fallback_allowed).toEqual({
+      "cli-only": false,
+      "cli-preferred": true,
+      "mcp-only": false,
+      "mcp-preferred": true,
+      "handoff-only": false
+    });
+  });
+
+});

--- a/tests/mikuproject-bundle-smoke.test.js
+++ b/tests/mikuproject-bundle-smoke.test.js
@@ -23,6 +23,14 @@ const builtNodeSourcesPath = path.resolve(
   ROOT,
   "bundle/mikuproject-skills/skills/mikuproject/runtime/mikuproject-sources.tgz"
 );
+const sourcePolicyConfigPath = path.resolve(
+  ROOT,
+  "skills/mikuproject/config/backend-policy.json"
+);
+const builtPolicyConfigPath = path.resolve(
+  ROOT,
+  "bundle/mikuproject-skills/skills/mikuproject/config/backend-policy.json"
+);
 
 describe("mikuproject bundle smoke", () => {
   const tempDirs = [];
@@ -77,6 +85,9 @@ describe("mikuproject bundle smoke", () => {
     expect(fs.existsSync(builtJavaRuntimePath)).toBe(true);
     expect(fs.existsSync(builtJavaSourcesPath)).toBe(true);
     expect(fs.existsSync(builtNodeSourcesPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(builtPolicyConfigPath, "utf8"))).toEqual(
+      JSON.parse(fs.readFileSync(sourcePolicyConfigPath, "utf8"))
+    );
     expect(nodeHelp).toContain("mikuproject report all");
     expect(nodeVersion).toMatch(/^mikuproject \d+\.\d+\.\d+/);
     expect(javaHelp).toContain("ai spec");

--- a/tests/mikuproject-phase-c-smoke.test.js
+++ b/tests/mikuproject-phase-c-smoke.test.js
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const nodeRuntimePath = path.resolve(ROOT, "skills/mikuproject/runtime/mikuproject.mjs");
+const javaRuntimePath = path.resolve(ROOT, "skills/mikuproject/runtime/mikuproject.jar");
+
+const runtimes = [
+  {
+    name: "Node.js",
+    command: "node",
+    prefixArgs: [nodeRuntimePath]
+  },
+  {
+    name: "Java",
+    command: "java",
+    prefixArgs: ["-jar", javaRuntimePath]
+  }
+];
+
+describe("mikuproject Phase C report export smoke", () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  for (const runtime of runtimes) {
+    it(`supports WBS XLSX, SVG, Markdown, Mermaid, and report bundle exports with ${runtime.name}`, () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mikuproject-phase-c-test-"));
+      tempDirs.push(tempRoot);
+
+      const draftPath = path.resolve(tempRoot, "draft.editjson");
+      const workbookPath = path.resolve(tempRoot, "workbook.json");
+      const wbsXlsxPath = path.resolve(tempRoot, "wbs.xlsx");
+      const dailySvgPath = path.resolve(tempRoot, "daily.svg");
+      const weeklySvgPath = path.resolve(tempRoot, "weekly.svg");
+      const monthlyCalendarPath = path.resolve(tempRoot, "monthly-calendar.zip");
+      const markdownPath = path.resolve(tempRoot, "wbs.md");
+      const mermaidPath = path.resolve(tempRoot, "mermaid.mmd");
+      const reportBundlePath = path.resolve(tempRoot, "report-bundle.zip");
+
+      fs.writeFileSync(draftPath, `${JSON.stringify(buildDraft(), null, 2)}\n`, "utf8");
+
+      runRuntime(runtime, [
+        "state",
+        "from-draft",
+        "--in",
+        draftPath,
+        "--out",
+        workbookPath
+      ], tempRoot);
+
+      runRuntime(runtime, [
+        "report",
+        "wbs-xlsx",
+        "--in",
+        workbookPath,
+        "--out",
+        wbsXlsxPath
+      ], tempRoot);
+      expectZipLikeFile(wbsXlsxPath);
+
+      runRuntime(runtime, [
+        "report",
+        "daily-svg",
+        "--in",
+        workbookPath,
+        "--out",
+        dailySvgPath
+      ], tempRoot);
+      expect(fs.readFileSync(dailySvgPath, "utf8")).toContain("<svg");
+
+      runRuntime(runtime, [
+        "report",
+        "weekly-svg",
+        "--in",
+        workbookPath,
+        "--out",
+        weeklySvgPath
+      ], tempRoot);
+      expect(fs.readFileSync(weeklySvgPath, "utf8")).toContain("<svg");
+
+      runRuntime(runtime, [
+        "report",
+        "monthly-calendar-svg",
+        "--in",
+        workbookPath,
+        "--out",
+        monthlyCalendarPath
+      ], tempRoot);
+      expectZipLikeFile(monthlyCalendarPath);
+
+      runRuntime(runtime, [
+        "report",
+        "wbs-markdown",
+        "--in",
+        workbookPath,
+        "--out",
+        markdownPath
+      ], tempRoot);
+      const markdown = fs.readFileSync(markdownPath, "utf8");
+      expect(markdown).toContain("# WBS");
+      expect(markdown).toContain("Phase C Report Smoke");
+
+      runRuntime(runtime, [
+        "report",
+        "mermaid",
+        "--in",
+        workbookPath,
+        "--out",
+        mermaidPath
+      ], tempRoot);
+      const mermaid = fs.readFileSync(mermaidPath, "utf8");
+      expect(mermaid).toContain("gantt");
+      expect(mermaid).toContain("Implementation");
+
+      runRuntime(runtime, [
+        "report",
+        "all",
+        "--in",
+        workbookPath,
+        "--out",
+        reportBundlePath
+      ], tempRoot);
+      expectZipLikeFile(reportBundlePath);
+    });
+  }
+});
+
+function runRuntime(runtime, args, cwd) {
+  return execFileSync(runtime.command, [...runtime.prefixArgs, ...args], {
+    cwd,
+    encoding: "utf8"
+  });
+}
+
+function expectZipLikeFile(filePath) {
+  const buffer = fs.readFileSync(filePath);
+  expect(buffer.length).toBeGreaterThan(0);
+  expect(buffer.subarray(0, 2).toString("utf8")).toBe("PK");
+}
+
+function buildDraft() {
+  return {
+    view_type: "project_draft_view",
+    project: {
+      name: "Phase C Report Smoke",
+      planned_start: "2026-04-01",
+      planned_finish: "2026-04-10"
+    },
+    tasks: [
+      {
+        uid: "draft-1",
+        name: "Planning",
+        parent_uid: null,
+        position: 0,
+        planned_start: "2026-04-01",
+        planned_finish: "2026-04-02"
+      },
+      {
+        uid: "draft-2",
+        name: "Implementation",
+        parent_uid: null,
+        position: 1,
+        planned_start: "2026-04-03",
+        planned_finish: "2026-04-08",
+        predecessor_uids: ["draft-1"]
+      },
+      {
+        uid: "draft-3",
+        name: "Review",
+        parent_uid: null,
+        position: 2,
+        is_milestone: true,
+        planned_start: "2026-04-10",
+        planned_finish: "2026-04-10",
+        predecessor_uids: ["draft-2"]
+      }
+    ],
+    resources: [],
+    assignments: []
+  };
+}


### PR DESCRIPTION
## 概要

`mikuproject` Agent Skill の実行 backend policy を文書化・設定ファイル化し、CLI backend / MCP backend / handoff backend の扱いを整理しました。あわせて Phase C の report / presentation 出力について、Node.js runtime と Java runtime の smoke test を追加しました。

## 変更内容

- `cli-only`、`cli-preferred`、`mcp-only`、`mcp-preferred`、`handoff-only` の backend policy を整理
- skill-local 設定ファイル `skills/mikuproject/config/backend-policy.json` を追加
- `SKILL.md`、quickstart、development notes、Agent Skill 設計文書に backend policy の優先順位と fallback ルールを追記
- CLI backend と MCP backend の operation 対応表、MCP resource / artifact role の説明を追加
- Agent Skill 設計文書を `v20260425` から `v20260429` へ更新
- README に CLI backend / MCP backend と `mikuproject-mcp` の補足を追加
- Phase C report export の smoke test を追加
  - `WBS XLSX`
  - daily SVG
  - weekly SVG
  - monthly calendar SVG
  - WBS Markdown
  - Mermaid
  - report bundle
- backend policy config の contract test を追加
- bundle smoke test で backend policy config の同梱を確認するように更新
- TODO を更新し、Phase C と backend policy 関連の完了状況を反映

## 確認

- `npm test`