### PR TITLE
backend policy の selector contract と operation registry を追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -266,6 +266,8 @@ MCP backend を使えるようにする。
 - [x] fallback した場合は、どの backend からどの backend へ移ったかを concise diagnostics として返す
 - [x] skill-local 設定ファイル `skills/mikuproject/config/backend-policy.json` を追加する
 - [x] 設定ファイルをユーザー明示指示と実行環境 policy より下位に置くことを文書化する
+- [x] policy と operation capability から backend 実行計画を決める純粋 helper `skills/mikuproject/lib/backend-policy.mjs` を追加する
+- [x] Agent Skill operation から CLI invocation と MCP tool 名を引く registry `skills/mikuproject/lib/backend-operations.mjs` を追加する
 
 ### Next implementation handoff
 
@@ -292,6 +294,8 @@ MCP backend を使えるようにする。
 - 2026-04-29: `workplace/mikuproject-mcp-devel` で `npm install` 後に `npm run build && npm run test` が通過した
 - 2026-04-29: root の `npm test` が通過した
 - 2026-04-29: `skills/mikuproject/config/backend-policy.json` を追加し、bundle 同梱と policy contract を `tests/mikuproject-backend-policy-config.test.js` で確認するようにした
+- 2026-04-29: `tests/mikuproject-backend-policy-selector.test.js` を追加し、CLI/MCP を実行しない selector contract として strict policy / fallback / report export policy を確認するようにした
+- 2026-04-29: `tests/mikuproject-backend-operations.test.js` を追加し、operation capability、CLI invocation builder、MCP tool 名の対応を確認するようにした
 
 `mikuproject-mcp` 側への申し送り:
 
@@ -301,12 +305,12 @@ MCP backend を使えるようにする。
 
 ### Tests and smoke checks
 
-- [ ] `cli-only` policy で MCP fallback しないことを smoke test する
-- [ ] `mcp-only` policy で CLI fallback しないことを smoke test する
-- [ ] `cli-preferred` policy で CLI unavailable 時に MCP へ fallback するケースを smoke test する
-- [ ] `mcp-preferred` policy で MCP unavailable 時に CLI へ fallback するケースを smoke test する
-- [ ] `handoff-only` policy で backend 実行しないことを smoke test する
-- [ ] report export 系でも backend policy が同じルールで適用されることを確認する
+- [x] `cli-only` policy で MCP fallback しないことを smoke test する
+- [x] `mcp-only` policy で CLI fallback しないことを smoke test する
+- [x] `cli-preferred` policy で CLI unavailable 時に MCP へ fallback するケースを smoke test する
+- [x] `mcp-preferred` policy で MCP unavailable 時に CLI へ fallback するケースを smoke test する
+- [x] `handoff-only` policy で backend 実行しないことを smoke test する
+- [x] report export 系でも backend policy が同じルールで適用されることを確認する
 
 ### Out of scope for this policy work
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -115,6 +115,19 @@ skill-local 設定:
 - 優先順位は `user-request`、`environment-policy`、`skill-config`、`repository-default`
 - ユーザー明示指示や実行環境 policy と衝突する場合、設定ファイル側を優先しない
 
+policy selector:
+
+- `skills/mikuproject/lib/backend-policy.mjs`
+- CLI や MCP を実行せず、policy と operation capability から実行 backend の候補を決める純粋 helper として扱う
+- 実際の backend runner が追加される場合も、この helper の strict policy / fallback contract を崩さない
+
+backend operation registry:
+
+- `skills/mikuproject/lib/backend-operations.mjs`
+- Agent Skill operation から CLI invocation と MCP tool 名を引くための小さな registry として扱う
+- CLI invocation builder は command / args を返すだけで、CLI process は実行しない
+- MCP tool 名が `null` の operation は、現行 MCP backend では未対応として扱う
+
 policy 値:
 
 - `cli-only`: CLI backend だけを使い、MCP fallback しない

--- a/skills/mikuproject/lib/backend-operations.mjs
+++ b/skills/mikuproject/lib/backend-operations.mjs
@@ -1,0 +1,142 @@
+export const DEFAULT_JAVA_RUNTIME_PATH = "skills/mikuproject/runtime/mikuproject.jar";
+export const DEFAULT_NODE_RUNTIME_PATH = "skills/mikuproject/runtime/mikuproject.mjs";
+
+export const operationRegistry = {
+  spec: {
+    cliArgs: ["ai", "spec"],
+    mcpTool: "mikuproject.ai_spec",
+    requires: []
+  },
+  draft: {
+    cliArgs: ["state", "from-draft"],
+    mcpTool: "mikuproject.state_from_draft",
+    requires: ["inputPath", "outputPath"]
+  },
+  patch: {
+    cliArgs: ["state", "apply-patch"],
+    mcpTool: "mikuproject.state_apply_patch",
+    requires: ["statePath", "inputPath", "outputPath"]
+  },
+  "workbook-export": {
+    cliArgs: ["export", "workbook-json"],
+    mcpTool: "mikuproject.export_workbook_json",
+    requires: ["inputPath", "outputPath"]
+  },
+  "wbs-markdown-export": {
+    cliArgs: ["report", "wbs-markdown"],
+    mcpTool: "mikuproject.report_wbs_markdown",
+    requires: ["inputPath", "outputPath"]
+  },
+  "mermaid-export": {
+    cliArgs: ["report", "mermaid"],
+    mcpTool: "mikuproject.report_mermaid",
+    requires: ["inputPath", "outputPath"]
+  },
+  "wbs-xlsx-export": {
+    cliArgs: ["report", "wbs-xlsx"],
+    mcpTool: null,
+    requires: ["inputPath", "outputPath"]
+  },
+  "daily-svg-export": {
+    cliArgs: ["report", "daily-svg"],
+    mcpTool: null,
+    requires: ["inputPath", "outputPath"]
+  },
+  "weekly-svg-export": {
+    cliArgs: ["report", "weekly-svg"],
+    mcpTool: null,
+    requires: ["inputPath", "outputPath"]
+  },
+  "monthly-calendar-svg-export": {
+    cliArgs: ["report", "monthly-calendar-svg"],
+    mcpTool: null,
+    requires: ["inputPath", "outputPath"]
+  },
+  "all-report-export": {
+    cliArgs: ["report", "all"],
+    mcpTool: null,
+    requires: ["inputPath", "outputPath"]
+  }
+};
+
+export const operationCapabilities = Object.fromEntries(
+  Object.entries(operationRegistry).map(([operation, definition]) => [
+    operation,
+    {
+      cli: Boolean(definition.cliArgs),
+      mcp: Boolean(definition.mcpTool)
+    }
+  ])
+);
+
+export function buildCliInvocation({
+  operation,
+  runtime = "java",
+  inputPath,
+  outputPath,
+  statePath,
+  javaRuntimePath = DEFAULT_JAVA_RUNTIME_PATH,
+  nodeRuntimePath = DEFAULT_NODE_RUNTIME_PATH
+} = {}) {
+  const definition = operationRegistry[operation];
+  if (!definition?.cliArgs) {
+    throw new Error(`unsupported CLI operation: ${operation}`);
+  }
+
+  assertRequiredFields(definition.requires, {
+    inputPath,
+    outputPath,
+    statePath
+  }, operation);
+
+  const operationArgs = [...definition.cliArgs];
+  appendPathArgs(operationArgs, {
+    inputPath,
+    outputPath,
+    statePath
+  });
+
+  if (runtime === "java") {
+    return {
+      command: "java",
+      args: ["-jar", javaRuntimePath, ...operationArgs]
+    };
+  }
+
+  if (runtime === "node") {
+    return {
+      command: "node",
+      args: [nodeRuntimePath, ...operationArgs]
+    };
+  }
+
+  throw new Error(`unsupported CLI runtime: ${runtime}`);
+}
+
+export function getMcpToolName(operation) {
+  return operationRegistry[operation]?.mcpTool ?? null;
+}
+
+function appendPathArgs(args, {
+  inputPath,
+  outputPath,
+  statePath
+}) {
+  if (statePath) {
+    args.push("--state", statePath);
+  }
+  if (inputPath) {
+    args.push("--in", inputPath);
+  }
+  if (outputPath) {
+    args.push("--out", outputPath);
+  }
+}
+
+function assertRequiredFields(requiredFields, values, operation) {
+  for (const field of requiredFields) {
+    if (!values[field]) {
+      throw new Error(`missing ${field} for operation: ${operation}`);
+    }
+  }
+}

--- a/skills/mikuproject/lib/backend-policy.mjs
+++ b/skills/mikuproject/lib/backend-policy.mjs
@@ -1,0 +1,148 @@
+import { operationCapabilities } from "./backend-operations.mjs";
+
+export const BACKEND_POLICIES = [
+  "cli-only",
+  "cli-preferred",
+  "mcp-only",
+  "mcp-preferred",
+  "handoff-only"
+];
+
+export const DEFAULT_OPERATION_CAPABILITIES = operationCapabilities;
+
+export function resolveBackendPolicy({
+  userRequestPolicy,
+  environmentPolicy,
+  skillConfigPolicy,
+  repositoryDefaultPolicy = "cli-preferred"
+} = {}, config = {}) {
+  const allowedPolicies = config.allowed_policies ?? BACKEND_POLICIES;
+  const policy =
+    userRequestPolicy ??
+    environmentPolicy ??
+    skillConfigPolicy ??
+    config.default_policy ??
+    repositoryDefaultPolicy;
+
+  assertAllowedPolicy(policy, allowedPolicies);
+  return policy;
+}
+
+export function planBackendExecution({
+  policy,
+  operation,
+  capabilities = DEFAULT_OPERATION_CAPABILITIES,
+  unavailableBackends = []
+} = {}) {
+  assertAllowedPolicy(policy, BACKEND_POLICIES);
+
+  if (!operation) {
+    throw new Error("operation is required");
+  }
+
+  if (policy === "handoff-only") {
+    return {
+      policy,
+      operation,
+      mode: "handoff",
+      selectedBackend: null,
+      attemptedBackends: [],
+      fallback: null,
+      error: null
+    };
+  }
+
+  const operationCapabilities = capabilities[operation];
+  if (!operationCapabilities) {
+    return hardError(policy, operation, [], "unknown_operation");
+  }
+
+  const backendOrder = backendOrderForPolicy(policy);
+  const fallbackAllowed = policy.endsWith("-preferred");
+  const unavailable = new Set(unavailableBackends);
+  const attemptedBackends = [];
+
+  for (const backend of backendOrder) {
+    attemptedBackends.push(backend);
+
+    if (!operationCapabilities[backend]) {
+      if (!fallbackAllowed) {
+        return hardError(policy, operation, attemptedBackends, `${backend}_not_supported`);
+      }
+      continue;
+    }
+
+    if (unavailable.has(backend)) {
+      if (!fallbackAllowed) {
+        return hardError(policy, operation, attemptedBackends, `${backend}_unavailable`);
+      }
+      continue;
+    }
+
+    const primaryBackend = backendOrder[0];
+    const fallback = backend === primaryBackend
+      ? null
+      : {
+          from: primaryBackend,
+          to: backend,
+          reason: fallbackReason(primaryBackend, operationCapabilities, unavailable)
+        };
+
+    return {
+      policy,
+      operation,
+      mode: "execute",
+      selectedBackend: backend,
+      attemptedBackends,
+      fallback,
+      error: null
+    };
+  }
+
+  return hardError(policy, operation, attemptedBackends, "no_allowed_backend_available");
+}
+
+function backendOrderForPolicy(policy) {
+  switch (policy) {
+    case "cli-only":
+      return ["cli"];
+    case "cli-preferred":
+      return ["cli", "mcp"];
+    case "mcp-only":
+      return ["mcp"];
+    case "mcp-preferred":
+      return ["mcp", "cli"];
+    default:
+      throw new Error(`unsupported backend policy: ${policy}`);
+  }
+}
+
+function fallbackReason(primaryBackend, operationCapabilities, unavailable) {
+  if (!operationCapabilities[primaryBackend]) {
+    return `${primaryBackend}_not_supported`;
+  }
+  if (unavailable.has(primaryBackend)) {
+    return `${primaryBackend}_unavailable`;
+  }
+  return `${primaryBackend}_unsuitable`;
+}
+
+function hardError(policy, operation, attemptedBackends, reason) {
+  return {
+    policy,
+    operation,
+    mode: "error",
+    selectedBackend: null,
+    attemptedBackends,
+    fallback: null,
+    error: {
+      reason
+    }
+  };
+}
+
+function assertAllowedPolicy(policy, allowedPolicies) {
+  if (!allowedPolicies.includes(policy)) {
+    throw new Error(`unsupported backend policy: ${policy}`);
+  }
+}

--- a/tests/mikuproject-backend-operations.test.js
+++ b/tests/mikuproject-backend-operations.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCliInvocation,
+  getMcpToolName,
+  operationCapabilities
+} from "../skills/mikuproject/lib/backend-operations.mjs";
+
+describe("mikuproject backend operation registry", () => {
+  it("exposes operation capabilities for backend policy selection", () => {
+    expect(operationCapabilities["spec"]).toEqual({ cli: true, mcp: true });
+    expect(operationCapabilities["wbs-markdown-export"]).toEqual({ cli: true, mcp: true });
+    expect(operationCapabilities["wbs-xlsx-export"]).toEqual({ cli: true, mcp: false });
+  });
+
+  it("builds Java CLI invocations for report exports", () => {
+    const invocation = buildCliInvocation({
+      operation: "wbs-xlsx-export",
+      runtime: "java",
+      inputPath: "state/workbook.json",
+      outputPath: "report/wbs.xlsx"
+    });
+
+    expect(invocation).toEqual({
+      command: "java",
+      args: [
+        "-jar",
+        "skills/mikuproject/runtime/mikuproject.jar",
+        "report",
+        "wbs-xlsx",
+        "--in",
+        "state/workbook.json",
+        "--out",
+        "report/wbs.xlsx"
+      ]
+    });
+  });
+
+  it("builds Node.js CLI invocations for draft import", () => {
+    const invocation = buildCliInvocation({
+      operation: "draft",
+      runtime: "node",
+      inputPath: "state/draft.editjson",
+      outputPath: "state/workbook.json"
+    });
+
+    expect(invocation).toEqual({
+      command: "node",
+      args: [
+        "skills/mikuproject/runtime/mikuproject.mjs",
+        "state",
+        "from-draft",
+        "--in",
+        "state/draft.editjson",
+        "--out",
+        "state/workbook.json"
+      ]
+    });
+  });
+
+  it("builds CLI invocations requiring base state for patch apply", () => {
+    const invocation = buildCliInvocation({
+      operation: "patch",
+      runtime: "java",
+      statePath: "state/workbook.before.json",
+      inputPath: "state/patch.editjson",
+      outputPath: "state/workbook.after.json"
+    });
+
+    expect(invocation.args).toEqual([
+      "-jar",
+      "skills/mikuproject/runtime/mikuproject.jar",
+      "state",
+      "apply-patch",
+      "--state",
+      "state/workbook.before.json",
+      "--in",
+      "state/patch.editjson",
+      "--out",
+      "state/workbook.after.json"
+    ]);
+  });
+
+  it("returns MCP tool names only for MCP-supported operations", () => {
+    expect(getMcpToolName("spec")).toBe("mikuproject.ai_spec");
+    expect(getMcpToolName("wbs-markdown-export")).toBe("mikuproject.report_wbs_markdown");
+    expect(getMcpToolName("wbs-xlsx-export")).toBe(null);
+  });
+});

--- a/tests/mikuproject-backend-policy-config.test.js
+++ b/tests/mikuproject-backend-policy-config.test.js
@@ -3,6 +3,11 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  BACKEND_POLICIES,
+  resolveBackendPolicy
+} from "../skills/mikuproject/lib/backend-policy.mjs";
+
 const ROOT = process.cwd();
 const policyConfigPath = path.resolve(
   ROOT,
@@ -42,6 +47,27 @@ describe("mikuproject backend policy config", () => {
       "mcp-preferred": true,
       "handoff-only": false
     });
+    expect(config.allowed_policies).toEqual(BACKEND_POLICIES);
   });
 
+  it("resolves policy by user, environment, skill config, then repository default", () => {
+    const config = JSON.parse(fs.readFileSync(policyConfigPath, "utf8"));
+
+    expect(resolveBackendPolicy({
+      userRequestPolicy: "mcp-only",
+      environmentPolicy: "cli-only",
+      skillConfigPolicy: "cli-preferred"
+    }, config)).toBe("mcp-only");
+
+    expect(resolveBackendPolicy({
+      environmentPolicy: "cli-only",
+      skillConfigPolicy: "mcp-preferred"
+    }, config)).toBe("cli-only");
+
+    expect(resolveBackendPolicy({
+      skillConfigPolicy: "mcp-preferred"
+    }, config)).toBe("mcp-preferred");
+
+    expect(resolveBackendPolicy({}, config)).toBe("cli-preferred");
+  });
 });

--- a/tests/mikuproject-backend-policy-selector.test.js
+++ b/tests/mikuproject-backend-policy-selector.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planBackendExecution
+} from "../skills/mikuproject/lib/backend-policy.mjs";
+
+describe("mikuproject backend policy selector", () => {
+  it("does not use MCP fallback under cli-only", () => {
+    const plan = planBackendExecution({
+      policy: "cli-only",
+      operation: "spec",
+      unavailableBackends: ["cli"]
+    });
+
+    expect(plan.mode).toBe("error");
+    expect(plan.selectedBackend).toBe(null);
+    expect(plan.attemptedBackends).toEqual(["cli"]);
+    expect(plan.error.reason).toBe("cli_unavailable");
+  });
+
+  it("does not use CLI fallback under mcp-only", () => {
+    const plan = planBackendExecution({
+      policy: "mcp-only",
+      operation: "spec",
+      unavailableBackends: ["mcp"]
+    });
+
+    expect(plan.mode).toBe("error");
+    expect(plan.selectedBackend).toBe(null);
+    expect(plan.attemptedBackends).toEqual(["mcp"]);
+    expect(plan.error.reason).toBe("mcp_unavailable");
+  });
+
+  it("uses MCP fallback under cli-preferred when CLI is unavailable", () => {
+    const plan = planBackendExecution({
+      policy: "cli-preferred",
+      operation: "spec",
+      unavailableBackends: ["cli"]
+    });
+
+    expect(plan.mode).toBe("execute");
+    expect(plan.selectedBackend).toBe("mcp");
+    expect(plan.attemptedBackends).toEqual(["cli", "mcp"]);
+    expect(plan.fallback).toEqual({
+      from: "cli",
+      to: "mcp",
+      reason: "cli_unavailable"
+    });
+  });
+
+  it("uses CLI fallback under mcp-preferred when MCP is unavailable", () => {
+    const plan = planBackendExecution({
+      policy: "mcp-preferred",
+      operation: "spec",
+      unavailableBackends: ["mcp"]
+    });
+
+    expect(plan.mode).toBe("execute");
+    expect(plan.selectedBackend).toBe("cli");
+    expect(plan.attemptedBackends).toEqual(["mcp", "cli"]);
+    expect(plan.fallback).toEqual({
+      from: "mcp",
+      to: "cli",
+      reason: "mcp_unavailable"
+    });
+  });
+
+  it("does not execute any backend under handoff-only", () => {
+    const plan = planBackendExecution({
+      policy: "handoff-only",
+      operation: "spec"
+    });
+
+    expect(plan.mode).toBe("handoff");
+    expect(plan.selectedBackend).toBe(null);
+    expect(plan.attemptedBackends).toEqual([]);
+    expect(plan.error).toBe(null);
+  });
+
+  it("applies the same policy rules to report exports", () => {
+    const markdownPlan = planBackendExecution({
+      policy: "cli-preferred",
+      operation: "wbs-markdown-export",
+      unavailableBackends: ["cli"]
+    });
+
+    expect(markdownPlan.mode).toBe("execute");
+    expect(markdownPlan.selectedBackend).toBe("mcp");
+    expect(markdownPlan.fallback).toEqual({
+      from: "cli",
+      to: "mcp",
+      reason: "cli_unavailable"
+    });
+
+    const wbsXlsxPlan = planBackendExecution({
+      policy: "mcp-only",
+      operation: "wbs-xlsx-export"
+    });
+
+    expect(wbsXlsxPlan.mode).toBe("error");
+    expect(wbsXlsxPlan.selectedBackend).toBe(null);
+    expect(wbsXlsxPlan.attemptedBackends).toEqual(["mcp"]);
+    expect(wbsXlsxPlan.error.reason).toBe("mcp_not_supported");
+  });
+});


### PR DESCRIPTION
## 概要

`mikuproject-skills` の execution backend policy について、Markdown / JSON で定義済みの contract をテスト可能にする補助実装を追加しました。

この変更では CLI や MCP tool を実行する runner は追加せず、policy 解決、backend 実行計画、operation から CLI invocation / MCP tool 名を引くための小さな helper と、その contract test を追加しています。

## 変更内容

- `skills/mikuproject/lib/backend-policy.mjs` を追加
  - backend policy の許可値を定義
  - `user-request`、`environment-policy`、`skill-config`、`repository-default` の優先順で policy を解決
  - policy と operation capability から backend 実行計画を作成
  - `cli-only` / `mcp-only` / `handoff-only` の strict policy を表現
  - `cli-preferred` / `mcp-preferred` の fallback を表現

- `skills/mikuproject/lib/backend-operations.mjs` を追加
  - Agent Skill operation registry を追加
  - CLI invocation builder を追加
  - MCP tool 名の解決を追加
  - operation ごとの CLI / MCP capability を定義

- backend policy config test を拡張
  - `backend-policy.json` と helper 側の policy 定義が一致することを確認
  - policy 解決の優先順位を確認

- backend policy selector test を追加
  - `cli-only` で MCP fallback しないことを確認
  - `mcp-only` で CLI fallback しないことを確認
  - `cli-preferred` で CLI unavailable 時に MCP fallback することを確認
  - `mcp-preferred` で MCP unavailable 時に CLI fallback することを確認
  - `handoff-only` で backend 実行しないことを確認
  - report export 系にも同じ policy rule が適用されることを確認

- backend operation registry test を追加
  - operation capability を確認
  - Java / Node.js CLI invocation builder を確認
  - MCP 対応済み operation の tool 名を確認
  - MCP 未対応 operation が `null` を返すことを確認

- `docs/development.md` を更新
  - policy selector helper の位置づけを追記
  - backend operation registry の位置づけを追記
  - CLI process や MCP tool は実行しない helper であることを明記

- `TODO.md` を更新
  - backend policy helper / operation registry の追加を反映
  - backend policy smoke check 項目を完了に更新
  - 追加した test の検証メモを追記

## 注意点

- この変更は CLI / MCP の実行 runner 追加ではありません。
- 追加した helper は、backend policy と operation mapping の contract をテスト可能にするための補助実装です。
- CLI invocation builder は command / args を返すだけで、CLI process は実行しません。