### PR TITLE
WBSレビューとスケジュール調整の参照ワークフローを追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -202,9 +202,18 @@
 
 ### Other Future Candidates
 
-- [ ] WBS レビュー支援
-- [ ] スケジュール圧縮や分解の助言
-- [ ] 複数プロンプトテンプレートの整備
+- [x] WBS レビュー支援
+- [x] スケジュール圧縮や分解の助言
+- [x] 複数プロンプトテンプレートの整備
+
+検証メモ:
+
+- 2026-04-29: `skills/mikuproject/references/workflow/schedule-adjustment.md` を追加し、schedule compression / task split / review-to-patch flow を整理した
+- 2026-04-29: `tests/mikuproject-schedule-adjustment-reference.test.js` を追加し、schedule adjustment workflow の導線、Patch 操作、境界を確認するようにした
+- 2026-04-29: `skills/mikuproject/references/workflow/wbs-review.md` を追加し、projection 優先の WBS review と review-to-patch flow を整理した
+- 2026-04-29: `tests/mikuproject-wbs-review-reference.test.js` を追加し、WBS review workflow の導線と境界を確認するようにした
+- 2026-04-29: `skills/mikuproject/references/prompts/` に new WBS draft、existing WBS review、schedule compression、patch request の短いテンプレートを追加した
+- 2026-04-29: `tests/mikuproject-prompt-references.test.js` を追加し、prompt reference の存在、INDEX 導線、必須語彙を確認するようにした
 
 ## 12. Execution Backend Policy
 

--- a/skills/mikuproject/SKILL.md
+++ b/skills/mikuproject/SKILL.md
@@ -107,3 +107,4 @@ Do not overreach beyond the MVP.
 Read these only when needed:
 
 - [references/INDEX.md](references/INDEX.md) for detailed workflow, I/O, runtime, and example references
+- [references/prompts/](references/prompts/) for optional prompt templates for draft, review, schedule compression, and patch request handoff

--- a/skills/mikuproject/references/INDEX.md
+++ b/skills/mikuproject/references/INDEX.md
@@ -24,6 +24,12 @@ Use this index when you need detailed guidance beyond the core rules in `SKILL.m
 - [workflow/output-location-rules.md](workflow/output-location-rules.md)
   - default output paths
   - file naming
+- [workflow/wbs-review.md](workflow/wbs-review.md)
+  - existing WBS review workflow
+  - review-to-patch flow
+- [workflow/schedule-adjustment.md](workflow/schedule-adjustment.md)
+  - schedule compression and task split workflow
+  - schedule adjustment patch flow
 
 ## I/O
 
@@ -46,3 +52,14 @@ Use this index when you need detailed guidance beyond the core rules in `SKILL.m
 
 - [examples/file-workflow-examples.md](examples/file-workflow-examples.md)
   - short `xml/xlsx/workbook` import/export examples
+
+## Prompts
+
+- [prompts/new-wbs-draft.md](prompts/new-wbs-draft.md)
+  - new `project_draft_view` WBS draft prompt
+- [prompts/existing-wbs-review.md](prompts/existing-wbs-review.md)
+  - existing WBS review prompt for projections
+- [prompts/schedule-compression.md](prompts/schedule-compression.md)
+  - schedule tightening prompt for existing WBS projections
+- [prompts/patch-request.md](prompts/patch-request.md)
+  - focused `Patch JSON` request prompt

--- a/skills/mikuproject/references/prompts/existing-wbs-review.md
+++ b/skills/mikuproject/references/prompts/existing-wbs-review.md
@@ -1,0 +1,31 @@
+# Existing WBS Review Prompt
+
+Use this when the user wants an AI-assisted review of an existing `mikuproject` WBS.
+
+Prefer local projections over full workbook handoff when possible:
+
+- `project_overview_view`
+- `phase_detail_view`
+- `task_edit_view`
+
+## Prompt
+
+```text
+次に与える mikuproject の projection JSON をレビューしてください。
+
+レビューでは次を確認してください。
+
+- phase / milestone / task の構造が自然か
+- task の粒度が粗すぎないか、細かすぎないか
+- planned_start / planned_finish の順序に明らかな不整合がないか
+- dependency の抜けや過剰な依存がないか
+- milestone と通常 task の役割が混ざっていないか
+- summary task を直接編集すべきでない箇所がないか
+
+変更が必要な場合は、最後に Patch JSON 形式で提案してください。
+変更不要の場合は、空の operations を持つ Patch JSON を返してください。
+```
+
+## Expected Next Step
+
+Validate the returned `Patch JSON` before applying it.

--- a/skills/mikuproject/references/prompts/new-wbs-draft.md
+++ b/skills/mikuproject/references/prompts/new-wbs-draft.md
@@ -1,0 +1,25 @@
+# New WBS Draft Prompt
+
+Use this when the user wants to create a new `mikuproject` WBS from rough requirements.
+
+Do not use this for revising an existing workbook state. Existing revisions should use projection handoff and `Patch JSON`.
+
+## Prompt
+
+```text
+次に与える要件をもとに、mikuproject の project_draft_view 形式で WBS 草案を作成してください。
+
+出力では次を守ってください。
+
+- 新規作成なので Patch JSON ではなく project_draft_view を返してください。
+- phase / milestone / task の構造を優先してください。
+- 依存関係は各 task の predecessor_uids または predecessors[].task_uid に書いてください。
+- top-level dependencies は使わないでください。
+- task uid は draft-1, draft-2 のような仮 UID でかまいません。
+- 可能なら planned_start / planned_finish を入れてください。
+- 最後に JSON だけを 1 個返してください。
+```
+
+## Expected Next Step
+
+Import the returned `project_draft_view` with `draft` / `state from-draft`.

--- a/skills/mikuproject/references/prompts/patch-request.md
+++ b/skills/mikuproject/references/prompts/patch-request.md
@@ -1,0 +1,28 @@
+# Patch Request Prompt
+
+Use this when the user has described a concrete change to an existing `mikuproject` WBS.
+
+Use a focused projection whenever possible instead of handing off the full workbook.
+
+## Prompt
+
+```text
+次に与える mikuproject の projection JSON と変更要望をもとに、Patch JSON を作成してください。
+
+Patch JSON では次を守ってください。
+
+- task の field 更新は update_task を使ってください。
+- 親子関係や順序の変更は move_task を使ってください。
+- 依存関係の追加や解除は link_tasks / unlink_tasks を使ってください。
+- predecessor 一覧を update_task.fields に丸ごと入れないでください。
+- lag を指定する場合は lag または lag_hours のどちらか一方だけを使ってください。
+- summary task を直接編集してはいけない rules がある場合は従ってください。
+- allowed_edit_fields と allow_patch_ops にない変更は返さないでください。
+- 変更不要の場合は operations を空配列にしてください。
+
+最後に JSON だけを 1 個返してください。
+```
+
+## Expected Next Step
+
+Run `patch-validate` before `patch` / `state apply-patch`.

--- a/skills/mikuproject/references/prompts/schedule-compression.md
+++ b/skills/mikuproject/references/prompts/schedule-compression.md
@@ -1,0 +1,28 @@
+# Schedule Compression Prompt
+
+Use this when the user wants schedule tightening or duration review for an existing `mikuproject` WBS.
+
+This prompt is for proposing changes. It does not apply changes directly.
+
+## Prompt
+
+```text
+次に与える mikuproject の projection JSON をもとに、スケジュール圧縮案を検討してください。
+
+検討では次を守ってください。
+
+- 依存関係を無視して日付だけを前倒ししないでください。
+- milestone の意味を壊さないでください。
+- summary task を直接編集する提案は避けてください。
+- task の planned_start / planned_finish / planned_duration を中心に見直してください。
+- 依存関係を変える必要がある場合は link_tasks / unlink_tasks を使ってください。
+- lag を提案する場合は lag または lag_hours のどちらか一方だけを使ってください。
+- 根拠が弱い変更は提案しないでください。
+
+最後に Patch JSON 形式で変更案を返してください。
+変更不要の場合は、空の operations を持つ Patch JSON を返してください。
+```
+
+## Expected Next Step
+
+Validate the returned `Patch JSON`, apply it only after validation, and review the diff.

--- a/skills/mikuproject/references/workflow/schedule-adjustment.md
+++ b/skills/mikuproject/references/workflow/schedule-adjustment.md
@@ -1,0 +1,86 @@
+# Schedule Adjustment Workflow
+
+Use this reference when the user asks to tighten, compress, split, or otherwise
+adjust the schedule of an existing `mikuproject` WBS.
+
+This workflow proposes schedule changes. It does not guarantee that a business
+deadline is feasible.
+
+## Preferred Inputs
+
+Use a projection that exposes enough scheduling context.
+
+Preferred order:
+
+1. `phase_detail_view` for phase-level schedule and dependency review
+2. `task_edit_view` for focused adjustment of one task
+3. `project_overview_view` for deciding which phase needs deeper review
+
+Use full `mikuproject_workbook_json` only when projection handoff is unavailable
+or explicitly requested.
+
+## Adjustment Checklist
+
+Look for:
+
+- tasks that can run in parallel without breaking dependencies
+- tasks that are too broad and should be split before date adjustment
+- milestone dates that constrain the schedule
+- dependencies that may be missing, excessive, or pointing in the wrong direction
+- planned_start / planned_finish / planned_duration inconsistencies
+- task ranges that can be shortened only with an explicit assumption
+- schedule risk that should be reported instead of silently patched
+
+Do not move dates earlier only because the user wants compression. Preserve
+dependency meaning unless the user explicitly asks to change it.
+
+## Patch Candidates
+
+Use these Patch JSON operations when a change is justified:
+
+- `update_task` for planned_start / planned_finish / planned_duration changes
+- `add_task` when a broad task should be split into explicit child work
+- `move_task` when the split task needs a different parent or order
+- `link_tasks` / `unlink_tasks` when dependency changes are part of the schedule adjustment
+
+When generating lag, emit either `lag` or `lag_hours`, not both.
+
+Avoid direct summary task edits. Prefer changes to leaf tasks or explicit task
+structure changes.
+
+## Output Shape
+
+Return a short schedule adjustment summary first.
+
+Use these sections when useful:
+
+- `Compression Opportunities`: safe or likely candidates
+- `Split Candidates`: tasks that should be decomposed before schedule changes
+- `Dependency Changes`: proposed link / unlink changes
+- `Patch Candidate`: whether a `Patch JSON` proposal is appropriate
+- `Warnings`: assumptions, missing data, or limits
+
+If the safe change is clear, produce `Patch JSON` and validate it before applying.
+If the change depends on a business decision, ask for that decision instead of
+inventing dates or dependencies.
+
+## Patch Flow
+
+For schedule adjustment:
+
+1. export `phase_detail_view` or `task_edit_view`
+2. use the schedule prompt when needed: `references/prompts/schedule-compression.md`
+3. receive or create `Patch JSON`
+4. run `patch-validate`
+5. apply the patch only if validation succeeds
+6. run `state-diff`
+7. optionally export `WBS Markdown`, `WBS XLSX`, or SVG for human review
+
+## Boundaries
+
+- do not guarantee that a requested deadline is feasible
+- do not ignore dependencies to make the schedule shorter
+- do not change milestone meaning without explicit user intent
+- do not edit summary tasks directly when leaf-task changes are possible
+- do not use report exports as editable source
+- do not create a large rewrite when a local patch is enough

--- a/skills/mikuproject/references/workflow/wbs-review.md
+++ b/skills/mikuproject/references/workflow/wbs-review.md
@@ -1,0 +1,73 @@
+# WBS Review Workflow
+
+Use this reference when the user asks to review an existing `mikuproject` WBS.
+
+This workflow reviews the WBS structure and scheduling surface that `mikuproject`
+can expose. It does not certify business validity and does not replace browser
+visual review.
+
+## Preferred Inputs
+
+Use the smallest projection that gives enough context.
+
+Preferred order:
+
+1. `project_overview_view` for project-level structure and entry review
+2. `phase_detail_view` for phase-level structure, dependencies, and schedule review
+3. `task_edit_view` for focused task-level review
+
+Use full `mikuproject_workbook_json` only when projection handoff is unavailable
+or the user explicitly asks for full workbook inspection.
+
+## Review Checklist
+
+Check for:
+
+- unclear phase / milestone / task hierarchy
+- task granularity that is too broad or too small for WBS review
+- milestones that look like normal work tasks
+- summary tasks that appear to be edited directly
+- missing or excessive dependencies
+- dependency direction that looks suspicious from task names and dates
+- planned start / finish order problems
+- tasks whose planned date range is inconsistent with their role
+- obvious review warnings from the upstream runtime
+
+Do not infer missing business requirements that are not present in the user's
+request or the projection.
+
+## Output Shape
+
+Return a concise review summary first.
+
+Use these sections when useful:
+
+- `Findings`: concrete issues or risks found in the projection
+- `No Change Needed`: areas that look structurally acceptable
+- `Patch Candidate`: whether a `Patch JSON` proposal is appropriate
+- `Warnings`: upstream warnings or review limits
+
+If the user asked for changes, or if the review naturally leads to a small
+structural fix, request or generate `Patch JSON` and validate it before applying.
+
+If no safe change is clear, do not invent a patch. Report the review result and
+ask for the missing decision only when needed.
+
+## Patch Flow
+
+For a review that leads to edits:
+
+1. export the relevant projection
+2. use the review prompt when needed: `references/prompts/existing-wbs-review.md`
+3. receive or create `Patch JSON`
+4. run `patch-validate`
+5. apply the patch only if validation succeeds
+6. run `state-diff` when change review matters
+
+## Boundaries
+
+- do not claim that the WBS is business-complete
+- do not replace visual inspection in the `mikuproject` browser UI
+- do not rewrite the whole WBS when a local patch is enough
+- do not return ad-hoc Markdown tables as the reviewed WBS state
+- do not treat report exports as editable source

--- a/tests/mikuproject-prompt-references.test.js
+++ b/tests/mikuproject-prompt-references.test.js
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const referencesRoot = path.resolve(ROOT, "skills/mikuproject/references");
+const indexPath = path.resolve(referencesRoot, "INDEX.md");
+
+const promptReferences = [
+  {
+    path: "prompts/new-wbs-draft.md",
+    requiredTerms: ["project_draft_view", "predecessor_uids", "top-level dependencies"]
+  },
+  {
+    path: "prompts/existing-wbs-review.md",
+    requiredTerms: ["projection JSON", "Patch JSON", "operations"]
+  },
+  {
+    path: "prompts/schedule-compression.md",
+    requiredTerms: ["スケジュール圧縮", "link_tasks", "unlink_tasks"]
+  },
+  {
+    path: "prompts/patch-request.md",
+    requiredTerms: ["Patch JSON", "allowed_edit_fields", "allow_patch_ops"]
+  }
+];
+
+describe("mikuproject prompt references", () => {
+  it("lists all prompt references from the references index", () => {
+    const indexText = fs.readFileSync(indexPath, "utf8");
+
+    for (const promptReference of promptReferences) {
+      expect(indexText).toContain(promptReference.path);
+    }
+  });
+
+  it("keeps prompt references short and tied to mikuproject JSON workflows", () => {
+    for (const promptReference of promptReferences) {
+      const text = fs.readFileSync(path.resolve(referencesRoot, promptReference.path), "utf8");
+
+      expect(text).toContain("```text");
+      expect(text).toContain("Expected Next Step");
+      expect(text.length).toBeLessThan(2500);
+
+      for (const requiredTerm of promptReference.requiredTerms) {
+        expect(text).toContain(requiredTerm);
+      }
+    }
+  });
+});

--- a/tests/mikuproject-schedule-adjustment-reference.test.js
+++ b/tests/mikuproject-schedule-adjustment-reference.test.js
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const referencesRoot = path.resolve(ROOT, "skills/mikuproject/references");
+const indexPath = path.resolve(referencesRoot, "INDEX.md");
+const scheduleWorkflowPath = path.resolve(referencesRoot, "workflow/schedule-adjustment.md");
+
+describe("mikuproject schedule adjustment reference", () => {
+  it("is linked from the references index", () => {
+    const indexText = fs.readFileSync(indexPath, "utf8");
+    expect(indexText).toContain("workflow/schedule-adjustment.md");
+  });
+
+  it("defines schedule compression, split, patch, and boundary rules", () => {
+    const text = fs.readFileSync(scheduleWorkflowPath, "utf8");
+
+    expect(text).toContain("phase_detail_view");
+    expect(text).toContain("task_edit_view");
+    expect(text).toContain("project_overview_view");
+    expect(text).toContain("update_task");
+    expect(text).toContain("add_task");
+    expect(text).toContain("move_task");
+    expect(text).toContain("link_tasks");
+    expect(text).toContain("unlink_tasks");
+    expect(text).toContain("lag_hours");
+    expect(text).toContain("patch-validate");
+    expect(text).toContain("state-diff");
+    expect(text).toContain("do not guarantee");
+    expect(text).toContain("do not ignore dependencies");
+  });
+});

--- a/tests/mikuproject-wbs-review-reference.test.js
+++ b/tests/mikuproject-wbs-review-reference.test.js
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const referencesRoot = path.resolve(ROOT, "skills/mikuproject/references");
+const indexPath = path.resolve(referencesRoot, "INDEX.md");
+const reviewWorkflowPath = path.resolve(referencesRoot, "workflow/wbs-review.md");
+
+describe("mikuproject WBS review reference", () => {
+  it("is linked from the references index", () => {
+    const indexText = fs.readFileSync(indexPath, "utf8");
+    expect(indexText).toContain("workflow/wbs-review.md");
+  });
+
+  it("defines projection-first review and review-to-patch boundaries", () => {
+    const text = fs.readFileSync(reviewWorkflowPath, "utf8");
+
+    expect(text).toContain("project_overview_view");
+    expect(text).toContain("phase_detail_view");
+    expect(text).toContain("task_edit_view");
+    expect(text).toContain("Patch JSON");
+    expect(text).toContain("patch-validate");
+    expect(text).toContain("state-diff");
+    expect(text).toContain("does not certify business validity");
+    expect(text).toContain("does not replace browser");
+  });
+});


### PR DESCRIPTION
## 概要

`mikuproject` skill の参照資料として、WBSレビュー、スケジュール調整、プロンプトテンプレートを追加しました。

既存WBSに対するレビューやスケジュール圧縮・分解の助言を、projection 優先の workflow として整理し、必要に応じて `Patch JSON`、`patch-validate`、`state-diff` へつなぐ流れを文書化しています。

## 変更内容

- prompt template を追加
  - `new-wbs-draft`
  - `existing-wbs-review`
  - `schedule-compression`
  - `patch-request`

- WBSレビュー workflow を追加
  - `project_overview_view` / `phase_detail_view` / `task_edit_view` を優先する方針を整理
  - review checklist を追加
  - review summary の出力形を整理
  - review-to-patch flow を追加
  - business validity や browser visual review を置き換えない境界を明記

- スケジュール調整 workflow を追加
  - schedule compression / task split / dependency adjustment の観点を整理
  - `update_task` / `add_task` / `move_task` / `link_tasks` / `unlink_tasks` の使い分けを記載
  - `lag` / `lag_hours` の併記禁止を記載
  - `patch-validate`、apply、`state-diff`、必要に応じた report export への流れを整理
  - business deadline の実現可能性を保証しないこと、依存関係を無視しないことを明記

- references index と skill 本体の導線を更新
  - workflow reference へのリンクを追加
  - prompt template へのリンクを追加

- TODO を更新
  - WBSレビュー支援を完了に更新
  - スケジュール圧縮や分解の助言を完了に更新
  - 複数プロンプトテンプレートの整備を完了に更新
  - 検証メモを追記

- 参照資料向けテストを追加
  - prompt reference の存在、INDEX 導線、必須語彙を確認
  - WBS review workflow の導線と境界を確認
  - schedule adjustment workflow の導線、Patch 操作、境界を確認

## 注意点

- この変更は workflow / prompt reference の追加です。
- `mikuproject` runtime の変換処理や CLI / MCP 実行処理は変更していません。
- WBSレビューは business validity の保証ではなく、`mikuproject` が扱う projection と Patch workflow の範囲での支援として整理しています。