### PR TITLE
Primary file workflow の対象外項目を明確化

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -170,20 +170,27 @@
 - [x] `XLSX`
 - [x] `mikuproject_workbook_json`
 
-対象外:
+対象外 / Deferred:
 
-- [ ] `CSV`
-- [ ] AI 向け編集用 JSON 群
+- [x] `CSV`
+- [x] AI 向け編集用 JSON 群
   - `project_overview_view`
   - `phase_detail_view`
   - `task_edit_view`
   - `full bundle`
+
+補足:
+
+- `CSV` は primary file import/export workflow の対象外として維持する
+- AI 向け編集用 JSON 群は file workflow ではなく AI workflow / projection workflow として扱う
+- `full bundle` は全体把握や handoff の補助であり、primary import/export 形式としては扱わない
 
 設計メモ:
 
 - [x] `docs/file-import-export.md` に主要ファイル形式の import / export を統合して整理する
 - [x] `skills/mikuproject/SKILL.md` に Phase B の操作を反映する
 - [x] `skills/mikuproject/references/` に `xml/xlsx/workbook` の短い利用例を追加する
+- [x] `docs/file-import-export.md` に `CSV` と AI 向け編集用 JSON 群を対象外 / Deferred として明記する
 
 ### Phase C: Report / Presentation Outputs
 

--- a/docs/file-import-export.md
+++ b/docs/file-import-export.md
@@ -8,6 +8,15 @@
 - 構造忠実 workbook `XLSX`
 - `mikuproject_workbook_json`
 
+対象外 / Deferred:
+
+- `CSV`
+- AI 向け編集用 JSON 群
+  - `project_overview_view`
+  - `phase_detail_view`
+  - `task_edit_view`
+  - `ai_projection_bundle` / full bundle
+
 この文書では、旧 `Phase B` 系メモを統合し、現在の実装前提に合わせて整理しています。
 
 ## 位置づけ
@@ -23,6 +32,10 @@
 `Patch JSON` を使う AI workflow を優先します。
 
 会話境界の state は、引き続き `mikuproject_workbook_json` を優先します。
+
+`CSV` は primary file import/export workflow の対象外として扱います。
+AI 向け編集用 JSON 群は file workflow ではなく、projection / patch の AI workflow として扱います。
+`ai_projection_bundle` は全体把握や handoff の補助であり、primary import/export 形式ではありません。
 
 ## 現在の利用方針
 

--- a/tests/mikuproject-file-workflow-scope.test.js
+++ b/tests/mikuproject-file-workflow-scope.test.js
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const fileImportExportPath = path.resolve(ROOT, "docs/file-import-export.md");
+const todoPath = path.resolve(ROOT, "TODO.md");
+
+describe("mikuproject file workflow scope", () => {
+  it("documents CSV and AI editing JSON as out of scope for primary file workflow", () => {
+    const fileWorkflowText = fs.readFileSync(fileImportExportPath, "utf8");
+    const todoText = fs.readFileSync(todoPath, "utf8");
+
+    for (const text of [fileWorkflowText, todoText]) {
+      expect(text).toContain("対象外 / Deferred");
+      expect(text).toContain("CSV");
+      expect(text).toContain("project_overview_view");
+      expect(text).toContain("phase_detail_view");
+      expect(text).toContain("task_edit_view");
+    }
+
+    expect(fileWorkflowText).toContain("AI workflow");
+    expect(fileWorkflowText).toContain("primary import/export");
+    expect(fileWorkflowText).toContain("ai_projection_bundle");
+  });
+});


### PR DESCRIPTION
## 概要

Phase B の primary file import/export workflow について、`CSV` と AI 向け編集用 JSON 群を対象外 / Deferred として明確化しました。

`project_overview_view`、`phase_detail_view`、`task_edit_view`、`ai_projection_bundle` / full bundle は file workflow ではなく、AI workflow / projection workflow や handoff 補助として扱う方針を文書化しています。

## 変更内容

- `TODO.md` を更新
  - Phase B の `対象外` を `対象外 / Deferred` に変更
  - `CSV` を対象外として完了扱いに更新
  - AI 向け編集用 JSON 群を対象外として完了扱いに更新
  - `CSV` は primary file import/export workflow の対象外として維持することを追記
  - AI 向け編集用 JSON 群は file workflow ではなく AI workflow / projection workflow として扱うことを追記
  - `full bundle` は全体把握や handoff の補助であり、primary import/export 形式ではないことを追記

- `docs/file-import-export.md` を更新
  - 対象外 / Deferred として `CSV` と AI 向け編集用 JSON 群を追記
  - `project_overview_view`、`phase_detail_view`、`task_edit_view`、`ai_projection_bundle` / full bundle の位置づけを追記
  - `CSV` は primary file import/export workflow の対象外であることを明記
  - AI 向け編集用 JSON 群は projection / patch の AI workflow として扱うことを明記
  - `ai_projection_bundle` は全体把握や handoff の補助であり、primary import/export 形式ではないことを明記

- `tests/mikuproject-file-workflow-scope.test.js` を追加
  - `TODO.md` と `docs/file-import-export.md` に対象外 / Deferred の記載があることを確認
  - `CSV` と AI 向け編集用 JSON 群の文言が維持されていることを確認
  - `AI workflow`、`primary import/export`、`ai_projection_bundle` の位置づけが文書化されていることを確認

## 注意点

- この変更は scope 文書化とテスト追加のみです。
- `CSV` import/export や AI 向け編集用 JSON 群の file workflow 実装は追加していません。