### PR TITLE
Node.js parity backlog を deferred として明記

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -145,8 +145,13 @@
 
 以下は Java runtime 側が先に持っている direct command を Node.js runtime 側にも揃えるかどうかの検討項目。
 現状の Agent Skills 運用では Java runtime を優先できるため、直ちに blocker ではない。
+今すぐ upstream request は作らず、必要になった時点で再検討する。
 
 - [ ] upstream `mikuproject` 側で、ASIS 対応表に `Not available as a direct Node.js command` と記録した操作の Node.js 実装を追加してもらう
+  - Status: deferred
+  - 現時点では対応しない
+  - Java runtime 優先運用で回避できるため、`mikuproject-skills` の直近作業 blocker ではない
+  - Node.js runtime parity が必要になった場合に、upstream request 文書を新規作成する
   - workbook JSON の validate / replace import / merge import に相当する直接コマンドを追加する
   - XML validate に相当する直接コマンドを追加する
   - 構造 workbook `XLSX` の validate / replace import / merge import に相当する直接コマンドを追加する


### PR DESCRIPTION
## 概要

`TODO.md` の upstream `mikuproject` Node.js parity backlog について、現時点では対応しない deferred 項目として明確化しました。

Java runtime 優先運用で回避できるため、`mikuproject-skills` の直近作業 blocker ではないことを追記しています。

## 変更内容

- upstream `mikuproject` の optional parity backlog に補足を追加
  - 今すぐ upstream request は作らない
  - 必要になった時点で再検討する

- Node.js runtime parity 項目に status を追加
  - `Status: deferred`
  - 現時点では対応しない
  - Java runtime 優先運用で回避できるため、直近作業 blocker ではない
  - Node.js runtime parity が必要になった場合に、upstream request 文書を新規作成する

## 注意点

- この変更は `TODO.md` の状態整理のみです。
- Node.js runtime の direct command 追加依頼文書は作成していません。
- runtime artifact や CLI 実装は変更していません。