### PR TITLE
release-build の Java runtime 検証コマンドを現行 CLI に更新する

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -36,7 +36,7 @@ jobs:
           set -euo pipefail
           test -s skills/mikuproject/runtime/mikuproject.jar
           test -s skills/mikuproject/runtime/mikuproject.mjs
-          java -jar skills/mikuproject/runtime/mikuproject.jar export-ai-json-spec >/dev/null
+          java -jar skills/mikuproject/runtime/mikuproject.jar ai spec >/dev/null
           node skills/mikuproject/runtime/mikuproject.mjs ai spec >/dev/null
 
       - name: Build release bundle


### PR DESCRIPTION
## 概要

GitHub Actions の release build workflow で実行している Java runtime 検証コマンドを、現行の `mikuproject-java` CLI 形式に更新します。

## 変更内容

- `.github/workflows/release-build.yml` の `Verify runtime artifacts` step を修正
- Java runtime の AI spec 確認コマンドを旧形式から現行形式へ変更

変更前:

```bash
java -jar skills/mikuproject/runtime/mikuproject.jar export-ai-json-spec
```

変更後:

```bash
java -jar skills/mikuproject/runtime/mikuproject.jar ai spec
```

## 背景

現行 CLI では `export-ai-json-spec` が利用できず、`ai spec` が AI spec 出力用の command として表示されています。

## 確認

このコミットでは workflow 定義の 1 行のみを変更しています。

追加のテスト実行結果は、指定コミットの差分内には含まれていないため未確認です。