### PR TITLE
MCP backend の利用設定ガイドを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Typical things you can ask for:
 - For advanced workflows, the skill can also work with structured plan data such as workbook JSON.
 - The skill is designed as a workflow layer that can run as `Agent Skill over CLI backend` or `Agent Skill over MCP backend`, depending on the execution policy.
 - The MCP server adapter product is named `mikuproject-mcp`; MCP tools use `mikuproject_*` names such as `mikuproject_ai_spec`.
+- To use the MCP backend, see [`docs/mcp-backend-setup.md`](./docs/mcp-backend-setup.md).
 - If you are evaluating or developing the repository itself, see the documents under [`docs/`](./docs/).
 
 Developer-oriented entry points:
@@ -94,6 +95,7 @@ This project is licensed under the Apache License 2.0. See [`LICENSE`](./LICENSE
 - より高度な運用では、workbook JSON などの構造化された計画データも扱えます。
 - この skill は workflow layer として設計されており、実行 policy に応じて `Agent Skill over CLI backend` または `Agent Skill over MCP backend` として扱えます。
 - MCP server adapter の製品名は `mikuproject-mcp` で、MCP tool は `mikuproject_ai_spec` のような `mikuproject_*` 名を使います。
+- MCP backend を使う場合は [`docs/mcp-backend-setup.md`](./docs/mcp-backend-setup.md) を参照してください。
 - リポジトリ自体の評価や開発を行う場合は [`docs/`](./docs/) 以下の文書を参照してください。
 
 開発者向けの入口:

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,7 @@
 - skill 配置手順: [skill-installation.md](./skill-installation.md)
 - ファイル入出力: [file-import-export.md](./file-import-export.md)
 - レポート出力: [report-export.md](./report-export.md)
+- MCP backend 利用設定: [mcp-backend-setup.md](./mcp-backend-setup.md)
 - backend switching 手動テスト: [backend-switching-manual-test.md](./backend-switching-manual-test.md)
 - miku software 共通 overview: [miku-soft-00-overview-design-v20260427.md](./miku-soft-00-overview-design-v20260427.md)
 - upstream MCP tool surface 連絡メモ: [upstream-mikuproject-mcp-tool-surface-note.md](./upstream-mikuproject-mcp-tool-surface-note.md)

--- a/docs/mcp-backend-setup.md
+++ b/docs/mcp-backend-setup.md
@@ -1,0 +1,84 @@
+# MCP Backend Setup
+
+この文書は、`mikuproject-skills` から MCP backend を使うための最小設定メモです。
+
+`mikuproject-skills` は MCP server 本体を標準同梱しません。
+MCP backend を使う場合は、別配布の `mikuproject-mcp` を MCP client から起動します。
+
+## 位置づけ
+
+- `mikuproject-skills`: Agent Skill の workflow layer
+- `mikuproject-mcp`: MCP server adapter
+- `mikuproject-mcp` の server key は、MCP client 設定では短く `mikuproject` として構いません
+- MCP tool 名は `mikuproject_ai_spec` のような `mikuproject_*` 形式です
+
+`mikuproject-skills` 側の既定 backend policy は `cli-preferred` です。
+MCP backend を明示したい場合は、会話で `mcp-only` または `mcp-preferred` を指定します。
+
+例:
+
+```text
+mikuproject、mcp-only で AI spec を確認して
+```
+
+## VS Code 設定例
+
+VS Code で使う場合は、workspace の `.vscode/mcp.json` に MCP server 設定を置きます。
+
+例:
+
+```json
+{
+  "servers": {
+    "mikuproject": {
+      "type": "stdio",
+      "command": "npm",
+      "args": [
+        "exec",
+        "--yes",
+        "--package=${workspaceFolder}/workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz",
+        "--",
+        "mikuproject-mcp"
+      ],
+      "env": {
+        "MIKUPROJECT_MCP_WORKSPACE": "${workspaceFolder}/workplace/mikuproject-mcp-vscode"
+      }
+    }
+  }
+}
+```
+
+この例では、MCP server package を次に置いている前提です。
+
+```text
+workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz
+```
+
+生成物は次の下に出ます。
+
+```text
+workplace/mikuproject-mcp-vscode
+```
+
+`.vscode/mcp.json` と `workplace/` はローカル環境用として扱います。
+
+## 最小確認
+
+MCP server を起動できたら、まず `mikuproject_ai_spec` を呼び出します。
+
+期待:
+
+- `operation` が `mikuproject_ai_spec`
+- hard error ではない
+- `mikuproject://spec/ai-json` または AI spec 本文を参照できる
+
+次に tool list で `mikuproject_report_wbs_xlsx` などの report tools が見えることを確認します。
+見えない場合は、古い `mikuproject-mcp` package が起動している可能性があります。
+
+## 詳細確認
+
+tool list、prompt list、draft からの workbook state 作成、report 生成まで確認する場合は、
+[backend-switching-manual-test.md](./backend-switching-manual-test.md) を使います。
+
+この文書は利用者向けの最小設定メモであり、
+`backend-switching-manual-test.md` は開発者・検証者向けの手動テスト手順です。


### PR DESCRIPTION
## 概要

`mikuproject-skills` から MCP backend を使うための最小設定メモを追加します。

これまで MCP backend の詳細確認手順は `backend-switching-manual-test.md` にありましたが、このコミットでは利用者向けの入口として `docs/mcp-backend-setup.md` を追加し、README と development notes から参照できるようにします。

## 変更内容

- `docs/mcp-backend-setup.md` を追加
  - `mikuproject-skills` と `mikuproject-mcp` の位置づけを説明
  - MCP server 本体は標準同梱しないことを明記
  - `mcp-only` / `mcp-preferred` の指定例を追加
  - VS Code の `.vscode/mcp.json` 設定例を追加
  - `MIKUPROJECT_MCP_WORKSPACE` の設定例を追加
  - `mikuproject_ai_spec` による最小確認手順を追加
  - 詳細確認先として `backend-switching-manual-test.md` を案内

- `README.md` に MCP backend setup へのリンクを追加
  - English / 日本語の両方に追加

- `docs/development.md` の文書一覧に MCP backend 利用設定を追加

## 確認

このコミットの差分には、追加のテスト実行結果は含まれていないため未確認です。