### PR TITLE
HTTP MCP の content-mode 返却 contract を明文化する

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -117,6 +117,29 @@
 - [x] Skill の使い方を短くまとめる
 - [x] 今後の拡張候補を別枠で整理する
 
+### HTTP MCP / content-mode contract documentation
+
+- [x] `skills/mikuproject/references/runtime/operations-map.md` に HTTP MCP の content-mode 返却形を明記する
+  - `outputMode: "content"` の text output は top-level `text` ではなく `artifacts[].text` に入る
+  - `mikuproject_state_from_draft` の workbook JSON は `artifacts[].role === "workbook_state"` の `text`、または互換目的の `stdout` から読む
+  - Markdown / Mermaid / SVG などの report 出力は `report_output`、projection は `projection`、diagnostics は `diagnostics_log` の artifact role を優先して読む
+- [x] `docs/mcp-backend-setup.md` に VS Code HTTP MCP 設定例を追加する
+  - `type: "http"` と `url: "http://127.0.0.1:3000/mcp"` の例を stdio 例と並べる
+  - HTTP server は別プロセスで `mikuproject-mcp` の `dist/http.js` / `mikuproject-mcp-http` を起動する前提を明記する
+  - HTTP transport では host path 引数を使わず、`draftContent` / `workbookContent` / `stateContent` / `patchContent` / `inputBase64` と `outputMode` を使うことを明記する
+- [x] `docs/backend-switching-manual-test.md` に HTTP MCP 手動確認手順を追加する
+  - `initialize` / `tools/list` が HTTP 200 を返すことを確認する
+  - `mikuproject_state_from_draft` を `draftContent` + `outputMode: "content"` で呼び、`workbook_state` artifact を確認する
+  - 返却 payload の例を短く掲載し、`payload.text` を期待しないことを明記する
+- [x] `skills/mikuproject/lib/backend-operations.mjs` の MCP metadata を path-mode 専用から inline/content-mode も表現できる形へ更新する
+  - CLI `requires` と MCP `requires` を分ける
+  - MCP tool ごとに inline input fields、path input fields、text/binary output modes、primary artifact role を持たせる
+  - `draft` の primary artifact role は `workbook_state` とする
+- [x] MCP HTTP/content-mode の返却 contract を固定するテストを追加する
+  - `mikuproject_state_from_draft` の content-mode 結果から `workbook_state.text` を抽出できること
+  - `mikuproject_report_wbs_markdown` の content-mode 結果から `report_output.text` を抽出できること
+  - operation summary / diagnostics が inline artifacts として追加されても primary artifact 抽出が壊れないこと
+
 ## Cross-Cutting Note
 
 - [x] `mikuproject-skills` 側だけで無理に実装せず、upstream (`mikuproject`) 側の API 追加や公開面整理が妥当な場合は、その都度 `mikuproject` 側アクション候補として相談する

--- a/docs/backend-switching-manual-test.md
+++ b/docs/backend-switching-manual-test.md
@@ -2,8 +2,9 @@
 
 この文書は、VS Code で `mikuproject-skills` の MCP backend を手動確認するための手順です。
 
-この手順では MCP server を `workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz` から起動します。
-local checkout 版や GitHub Releases URL は使いません。
+この手順の主経路では MCP server を `workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz`
+から stdio で起動します。HTTP transport を確認する場合は、local checkout 版の
+HTTP entrypoint を別プロセスで起動する手順も使えます。
 
 ## 1. 前提確認
 
@@ -64,6 +65,31 @@ repository root に `.vscode/mcp.json` を作ります。
 ```text
 workplace/mikuproject-mcp-vscode
 ```
+
+HTTP transport を確認する場合は、MCP server を別プロセスで起動します。
+
+```bash
+MIKUPROJECT_MCP_HTTP_HOST=127.0.0.1 \
+MIKUPROJECT_MCP_HTTP_PORT=3000 \
+MIKUPROJECT_MCP_HTTP_ENDPOINT=/mcp \
+node /path/to/mikuproject-mcp/packages/node/dist/http.js
+```
+
+その場合の `.vscode/mcp.json` は次の形にします。
+
+```json
+{
+  "servers": {
+    "mikuproject": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp"
+    }
+  }
+}
+```
+
+HTTP transport では、MCP client はこの URL へ接続するだけです。server process
+の起動、停止、port 変更は別途管理します。
 
 ## 3. VS Code を再読み込みする
 
@@ -205,6 +231,47 @@ outputPath は ${workspaceFolder}/workplace/mikuproject-mcp-vscode/state/manual-
 - `workplace/mikuproject-mcp-vscode/state/manual-workbook.json` が生成される
 - artifact role が workbook state として扱われる
 
+HTTP transport / content-mode で確認する場合は、host path 引数を渡さず、
+`draftContent` と `outputMode: "content"` を使います。
+
+期待:
+
+- HTTP `initialize` が 200 を返す
+- HTTP `tools/list` が 200 を返し、`mikuproject_state_from_draft` が含まれる
+- `mikuproject_state_from_draft` の operation payload は `ok: true`
+- workbook JSON は top-level `text` ではなく、`artifacts[]` の
+  `role === "workbook_state"` の `text` に入る
+- `stdout` は互換用 fallback として扱えるが、primary artifact は role で選ぶ
+
+返却 payload の要点:
+
+```json
+{
+  "ok": true,
+  "operation": "mikuproject_state_from_draft",
+  "artifacts": [
+    {
+      "role": "workbook_state",
+      "text": "{...mikuproject_workbook_json...}",
+      "mimeType": "application/json"
+    },
+    {
+      "role": "operation_summary",
+      "text": "{...}",
+      "mimeType": "application/json"
+    },
+    {
+      "role": "diagnostics_log",
+      "text": "{...}",
+      "mimeType": "application/json"
+    }
+  ],
+  "stdout": "{...mikuproject_workbook_json...}"
+}
+```
+
+`payload.text` は期待しません。
+
 ## 9. WBS Markdown report を作る
 
 Copilot Chat で次を依頼します。
@@ -220,6 +287,12 @@ outputPath は ${workspaceFolder}/workplace/mikuproject-mcp-vscode/report/manual
 - `operation` が `mikuproject_report_wbs_markdown`
 - `workplace/mikuproject-mcp-vscode/report/manual-wbs.md` が生成される
 - report artifact として扱われる
+
+HTTP transport / content-mode で確認する場合は、`workbookContent` と
+`outputMode: "content"` を使います。Markdown 本文は `artifacts[]` の
+`role === "report_output"` の `text` に入ります。operation summary や
+diagnostics が同じ `artifacts[]` に追加されるため、配列位置ではなく role で
+選びます。
 
 ## 10. WBS XLSX report を作る
 

--- a/docs/mcp-backend-setup.md
+++ b/docs/mcp-backend-setup.md
@@ -25,7 +25,7 @@ mikuproject、mcp-only で AI spec を確認して
 
 VS Code で使う場合は、workspace の `.vscode/mcp.json` に MCP server 設定を置きます。
 
-例:
+### stdio 例
 
 ```json
 {
@@ -61,6 +61,47 @@ workplace/mikuproject-mcp-vscode
 ```
 
 `.vscode/mcp.json` と `workplace/` はローカル環境用として扱います。
+
+### HTTP 例
+
+HTTP transport で接続する場合は、MCP server を別プロセスで起動し、
+`.vscode/mcp.json` には接続先 URL だけを書きます。
+
+MCP server 起動例:
+
+```sh
+MIKUPROJECT_MCP_HTTP_HOST=127.0.0.1 \
+MIKUPROJECT_MCP_HTTP_PORT=3000 \
+MIKUPROJECT_MCP_HTTP_ENDPOINT=/mcp \
+node /path/to/mikuproject-mcp/packages/node/dist/http.js
+```
+
+`mikuproject-mcp-http` コマンドとしてインストール済みの場合は、同じ環境変数で
+そのコマンドを起動しても構いません。
+
+VS Code の `.vscode/mcp.json` 例:
+
+```json
+{
+  "servers": {
+    "mikuproject": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp"
+    }
+  }
+}
+```
+
+HTTP transport は request-scoped workspace を使うため、host path 引数を渡さない
+運用を基本にします。`draftContent` / `workbookContent` / `stateContent` /
+`patchContent` / `content` / `inputBase64` などの inline input と、
+`outputMode: "content"` または `outputMode: "base64"` を使います。
+
+content-mode の結果は、operation payload の top-level `text` ではなく
+`artifacts[]` に入ります。たとえば `mikuproject_state_from_draft` の workbook
+JSON は `artifacts[].role === "workbook_state"` の `text` を読みます。WBS
+Markdown や Mermaid などの report は `report_output.text`、WBS XLSX や ZIP
+bundle などの binary report は `report_output.base64` を読みます。
 
 ## 最小確認
 

--- a/skills/mikuproject/lib/backend-operations.mjs
+++ b/skills/mikuproject/lib/backend-operations.mjs
@@ -7,56 +7,132 @@ export const operationRegistry = {
   spec: {
     cliArgs: ["ai", "spec"],
     mcpTool: "mikuproject_ai_spec",
+    mcp: {
+      tool: "mikuproject_ai_spec",
+      inputFields: [],
+      outputModes: [],
+      primaryArtifactRole: "ai_spec"
+    },
     requires: []
   },
   draft: {
     cliArgs: ["state", "from-draft"],
     mcpTool: "mikuproject_state_from_draft",
+    mcp: {
+      tool: "mikuproject_state_from_draft",
+      pathInputFields: ["draftPath"],
+      inlineInputFields: ["draftContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "workbook_state"
+    },
     requires: ["inputPath", "outputPath"]
   },
   patch: {
     cliArgs: ["state", "apply-patch"],
     mcpTool: "mikuproject_state_apply_patch",
+    mcp: {
+      tool: "mikuproject_state_apply_patch",
+      pathInputFields: ["statePath", "patchPath"],
+      inlineInputFields: ["stateContent", "patchContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "workbook_state"
+    },
     requires: ["statePath", "inputPath", "outputPath"]
   },
   "workbook-export": {
     cliArgs: ["export", "workbook-json"],
     mcpTool: "mikuproject_export_workbook_json",
+    mcp: {
+      tool: "mikuproject_export_workbook_json",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "mikuproject_workbook_json"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "wbs-markdown-export": {
     cliArgs: ["report", "wbs-markdown"],
     mcpTool: "mikuproject_report_wbs_markdown",
+    mcp: {
+      tool: "mikuproject_report_wbs_markdown",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "mermaid-export": {
     cliArgs: ["report", "mermaid"],
     mcpTool: "mikuproject_report_mermaid",
+    mcp: {
+      tool: "mikuproject_report_mermaid",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "wbs-xlsx-export": {
     cliArgs: ["report", "wbs-xlsx"],
     mcpTool: "mikuproject_report_wbs_xlsx",
+    mcp: {
+      tool: "mikuproject_report_wbs_xlsx",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "base64"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "daily-svg-export": {
     cliArgs: ["report", "daily-svg"],
     mcpTool: "mikuproject_report_daily_svg",
+    mcp: {
+      tool: "mikuproject_report_daily_svg",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "weekly-svg-export": {
     cliArgs: ["report", "weekly-svg"],
     mcpTool: "mikuproject_report_weekly_svg",
+    mcp: {
+      tool: "mikuproject_report_weekly_svg",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "monthly-calendar-svg-export": {
     cliArgs: ["report", "monthly-calendar-svg"],
     mcpTool: "mikuproject_report_monthly_calendar_svg",
+    mcp: {
+      tool: "mikuproject_report_monthly_calendar_svg",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "base64"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   },
   "all-report-export": {
     cliArgs: ["report", "all"],
     mcpTool: "mikuproject_report_all",
+    mcp: {
+      tool: "mikuproject_report_all",
+      pathInputFields: ["workbookPath"],
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "base64"],
+      primaryArtifactRole: "report_output"
+    },
     requires: ["inputPath", "outputPath"]
   }
 };
@@ -124,6 +200,35 @@ export function buildCliInvocation({
 
 export function getMcpToolName(operation) {
   return operationRegistry[operation]?.mcpTool ?? null;
+}
+
+export function getMcpOperationMetadata(operation) {
+  return operationRegistry[operation]?.mcp ?? null;
+}
+
+export function getMcpPrimaryArtifactRole(operation) {
+  return getMcpOperationMetadata(operation)?.primaryArtifactRole ?? null;
+}
+
+export function extractMcpPrimaryArtifact(result, operation) {
+  const primaryRole = getMcpPrimaryArtifactRole(operation);
+  if (!primaryRole) {
+    return null;
+  }
+
+  const artifacts = Array.isArray(result?.artifacts) ? result.artifacts : [];
+  return artifacts.find((artifact) => artifact?.role === primaryRole) ?? null;
+}
+
+export function extractMcpPrimaryArtifactText(result, operation) {
+  const artifact = extractMcpPrimaryArtifact(result, operation);
+  if (typeof artifact?.text === "string") {
+    return artifact.text;
+  }
+  if (typeof result?.stdout === "string") {
+    return result.stdout;
+  }
+  return null;
 }
 
 function appendPathArgs(args, {

--- a/skills/mikuproject/references/runtime/operations-map.md
+++ b/skills/mikuproject/references/runtime/operations-map.md
@@ -74,7 +74,7 @@ MCP backend phase grouping:
 
 - Phase A: AI/state workflow tools used for spec, draft, projections, patch validation, patch apply, diff, summarize, and workbook JSON export
 - Phase B: primary file import/export tools for structural workbook XLSX and MS Project XML export
-- Phase C: report/presentation tools exposed by `mikuproject-mcp` 0.8.2, including WBS XLSX, SVG reports, report bundle, WBS Markdown, and Mermaid
+- Phase C: report/presentation tools exposed by `mikuproject-mcp` 0.8.2 and later, including WBS XLSX, SVG reports, report bundle, WBS Markdown, and Mermaid
 
 Current `mikuproject-mcp` does not expose every CLI import or merge operation.
 Under `mcp-only`, missing MCP tools remain unavailable rather than falling back
@@ -160,6 +160,44 @@ Important artifact roles shared with `mikuproject-mcp` include:
 - `report_output`
 - `operation_summary`
 - `diagnostics_log`
+
+## HTTP MCP Content-Mode Results
+
+When using Streamable HTTP, prefer inline inputs and content-return modes instead
+of host file paths.
+
+Use inline input fields such as:
+
+- `draftContent`
+- `workbookContent`
+- `stateContent`
+- `patchContent`
+- `content`
+- `inputBase64`
+
+For text outputs, set `outputMode: "content"`.
+For binary outputs, set `outputMode: "base64"`.
+
+In content mode, the generated output is not returned as a top-level `text`
+field on the parsed operation payload. The MCP tool result itself is still a
+text MCP message whose text is JSON, but after parsing that JSON, generated
+artifacts are found under `artifacts[]`.
+
+Read primary outputs by artifact role:
+
+| Operation | Primary artifact role | Field |
+| --- | --- | --- |
+| `draft` / `mikuproject_state_from_draft` | `workbook_state` | `artifacts[].text` |
+| `workbook-export` / `mikuproject_export_workbook_json` | `mikuproject_workbook_json` | `artifacts[].text` |
+| AI projection exports | `projection` | `artifacts[].text` |
+| text report exports such as WBS Markdown / Mermaid / SVG | `report_output` | `artifacts[].text` |
+| binary report exports such as WBS XLSX / ZIP bundles | `report_output` | `artifacts[].base64` |
+
+`stdout` may also contain the generated text output and can be used as a
+compatibility fallback. Do not expect `payload.text` after parsing the operation
+JSON. Operation summaries and diagnostics may also be appended to `artifacts[]`
+with roles `operation_summary` and `diagnostics_log`; select the primary
+artifact by role rather than by array position.
 
 ## Java / Node.js CLI Correspondence
 

--- a/tests/mikuproject-backend-operations.test.js
+++ b/tests/mikuproject-backend-operations.test.js
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCliInvocation,
+  extractMcpPrimaryArtifact,
+  extractMcpPrimaryArtifactText,
+  getMcpOperationMetadata,
+  getMcpPrimaryArtifactRole,
   getMcpToolName,
   operationCapabilities
 } from "../skills/mikuproject/lib/backend-operations.mjs";
@@ -97,5 +101,105 @@ describe("mikuproject backend operation registry", () => {
     expect(getMcpToolName("weekly-svg-export")).toBe("mikuproject_report_weekly_svg");
     expect(getMcpToolName("monthly-calendar-svg-export")).toBe("mikuproject_report_monthly_calendar_svg");
     expect(getMcpToolName("all-report-export")).toBe("mikuproject_report_all");
+  });
+
+  it("describes HTTP MCP content-mode fields and primary artifact roles", () => {
+    expect(getMcpOperationMetadata("draft")).toMatchObject({
+      tool: "mikuproject_state_from_draft",
+      inlineInputFields: ["draftContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "workbook_state"
+    });
+    expect(getMcpOperationMetadata("wbs-markdown-export")).toMatchObject({
+      tool: "mikuproject_report_wbs_markdown",
+      inlineInputFields: ["workbookContent"],
+      outputModes: ["path", "content"],
+      primaryArtifactRole: "report_output"
+    });
+    expect(getMcpOperationMetadata("wbs-xlsx-export")).toMatchObject({
+      outputModes: ["path", "base64"],
+      primaryArtifactRole: "report_output"
+    });
+  });
+
+  it("extracts workbook content from the primary MCP artifact, not top-level text", () => {
+    const result = {
+      ok: true,
+      operation: "mikuproject_state_from_draft",
+      artifacts: [
+        {
+          role: "workbook_state",
+          text: "{\"format\":\"mikuproject_workbook_json\"}",
+          mimeType: "application/json"
+        },
+        {
+          role: "operation_summary",
+          text: "{\"ok\":true}",
+          mimeType: "application/json"
+        },
+        {
+          role: "diagnostics_log",
+          text: "{\"diagnostics\":[]}",
+          mimeType: "application/json"
+        }
+      ],
+      stdout: "{\"format\":\"legacy_stdout_fallback\"}"
+    };
+
+    expect(getMcpPrimaryArtifactRole("draft")).toBe("workbook_state");
+    expect(extractMcpPrimaryArtifact(result, "draft")).toEqual({
+      role: "workbook_state",
+      text: "{\"format\":\"mikuproject_workbook_json\"}",
+      mimeType: "application/json"
+    });
+    expect(extractMcpPrimaryArtifactText(result, "draft")).toBe(
+      "{\"format\":\"mikuproject_workbook_json\"}"
+    );
+    expect(result.text).toBeUndefined();
+  });
+
+  it("extracts report content by role even when operation artifacts are inlined", () => {
+    const result = {
+      ok: true,
+      operation: "mikuproject_report_wbs_markdown",
+      artifacts: [
+        {
+          role: "operation_summary",
+          text: "{\"ok\":true}",
+          mimeType: "application/json"
+        },
+        {
+          role: "report_output",
+          text: "# WBS",
+          mimeType: "text/markdown"
+        },
+        {
+          role: "diagnostics_log",
+          text: "{\"diagnostics\":[]}",
+          mimeType: "application/json"
+        }
+      ]
+    };
+
+    expect(extractMcpPrimaryArtifactText(result, "wbs-markdown-export")).toBe("# WBS");
+  });
+
+  it("falls back to stdout for older MCP text results without inline artifact text", () => {
+    const result = {
+      ok: true,
+      operation: "mikuproject_state_from_draft",
+      artifacts: [
+        {
+          role: "workbook_state",
+          uri: "mikuproject://state/current",
+          path: "/tmp/current-workbook.json"
+        }
+      ],
+      stdout: "{\"format\":\"mikuproject_workbook_json\"}"
+    };
+
+    expect(extractMcpPrimaryArtifactText(result, "draft")).toBe(
+      "{\"format\":\"mikuproject_workbook_json\"}"
+    );
   });
 });

--- a/tests/mikuproject-mcp-tool-surface.test.js
+++ b/tests/mikuproject-mcp-tool-surface.test.js
@@ -43,17 +43,23 @@ const phaseCTools = [
 ];
 
 describe("mikuproject MCP tool surface fixtures", () => {
-  it("points the VS Code MCP config at the 0.8.2 tarball when the local config exists", () => {
+  it("points the VS Code MCP config at a supported mikuproject transport when the local config exists", () => {
     if (!fs.existsSync(mcpConfigPath)) {
       return;
     }
 
     const config = JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"));
-    const args = config.servers?.mikuproject?.args ?? [];
+    const server = config.servers?.mikuproject;
+    expect(server).toBeDefined();
 
-    expect(args).toContain(
-      "--package=${workspaceFolder}/workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz"
-    );
+    if (server.type === "http") {
+      expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+      return;
+    }
+
+    const args = server.args ?? [];
+    expect(server.type).toBe("stdio");
+    expect(args).toContain("--package=${workspaceFolder}/workplace/igapyon-mikuproject-mcp-node-0.8.2.tgz");
     expect(args.join(" ")).not.toContain("mikuproject-mcp-0.8.0");
   });
 


### PR DESCRIPTION
## 概要

`mikuproject` の MCP backend について、HTTP transport / content-mode 利用時の返却 contract を文書と metadata に明示します。

特に、`outputMode: "content"` の結果を top-level `text` として扱わず、`artifacts[]` の artifact role から primary output を取得する方針を追加します。

## 変更内容

- HTTP MCP / content-mode の返却形を `operations-map.md` に追記
  - `mikuproject_state_from_draft` の primary output は `workbook_state.text`
  - WBS Markdown / Mermaid / SVG などの report output は `report_output.text`
  - WBS XLSX / ZIP bundle などの binary output は `report_output.base64`
  - `operation_summary` / `diagnostics_log` が inline artifacts として追加されるため、配列位置ではなく role で選ぶ方針を明記
- VS Code 向け MCP backend setup に HTTP 設定例を追加
  - `type: "http"`
  - `url: "http://127.0.0.1:3000/mcp"`
  - HTTP server は別プロセスで起動する前提を明記
- backend switching manual test に HTTP transport / content-mode の確認手順を追加
- backend operation registry に MCP metadata を追加
  - inline input fields
  - path input fields
  - output modes
  - primary artifact role
- MCP primary artifact を role で抽出する helper を追加
- HTTP/content-mode の artifact 抽出 contract を固定するテストを追加
- `.vscode/mcp.json` のテストを stdio だけでなく HTTP 設定も許容するよう更新
- TODO に HTTP MCP / content-mode contract documentation の完了項目を追加

## テスト

- `mikuproject-backend-operations.test.js` に以下の確認を追加
  - `draft` の primary artifact role が `workbook_state` であること
  - WBS Markdown report の primary artifact role が `report_output` であること
  - top-level `text` ではなく primary artifact role から text を抽出すること
  - inline の `operation_summary` / `diagnostics_log` が混在しても primary artifact を取得できること
  - inline artifact text がない場合に `stdout` fallback を使えること

## 備考

この変更は、HTTP MCP の content-mode 結果を誤って `payload.text` として読むことを避けるための contract 明文化と回帰テスト追加です。