### PR TITLE
miku-project-skills を 0.12.0 へ更新

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -69,11 +69,11 @@ Git tag は別途作成するため、通常は `--no-git-tag-version` を付け
 例:
 
 ```bash
-npm version 0.8.2 --no-git-tag-version
+npm version 0.12.0 --no-git-tag-version
 ```
 
-`package.json` と `package-lock.json` では npm の SemVer として `0.8.2`
-のように記録します。Git tag やリリース名として `v0.8.2` を使う場合でも、
+`package.json` と `package-lock.json` では npm の SemVer として `0.12.0`
+のように記録します。Git tag やリリース名として `v0.12.0` を使う場合でも、
 package version には先頭の `v` を付けません。
 
 更新後は次で root package version が揃っていることを確認します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-project-skills",
-  "version": "0.8.2",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-project-skills",
-      "version": "0.8.2",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-project-skills",
-  "version": "0.8.2",
+  "version": "0.12.0",
   "private": true,
   "description": "Agent Skills for miku-project",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 概要

`miku-project-skills` の package version を 0.12.0 へ更新します。

## 変更内容

- `package.json` と `package-lock.json` の root package version を 0.12.0 へ更新
- 開発手順に記載した SemVer と Git tag の例を 0.12.0 に更新

## 確認

- `npm run build`（15 files / 39 tests passed）