### PR TITLE
Release workflowを修正し0.12.2へ更新

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          java_runtime="$(find skills/igapyon-miku-project/runtime -maxdepth 1 -type f -name 'miku-project-*.jar' ! -name '*-sources.jar' | sort -V | tail -n 1)"
+          java_runtime="$(find skills/igapyon-miku-project/runtime -maxdepth 1 -type f -name 'miku-project-*.jar' ! -name 'miku-project-sources-*.jar' | sort -V | tail -n 1)"
           node_runtime="$(find skills/igapyon-miku-project/runtime -maxdepth 1 -type f -name 'miku-project-*.mjs' | sort -V | tail -n 1)"
           test -n "${java_runtime}"
           test -n "${node_runtime}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,11 +69,11 @@ Git tag は別途作成するため、通常は `--no-git-tag-version` を付け
 例:
 
 ```bash
-npm version 0.12.1 --no-git-tag-version
+npm version 0.12.2 --no-git-tag-version
 ```
 
-`package.json` と `package-lock.json` では npm の SemVer として `0.12.1`
-のように記録します。Git tag やリリース名として `v0.12.1` を使う場合でも、
+`package.json` と `package-lock.json` では npm の SemVer として `0.12.2`
+のように記録します。Git tag やリリース名として `v0.12.2` を使う場合でも、
 package version には先頭の `v` を付けません。
 
 更新後は次で root package version が揃っていることを確認します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-project-skills",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-project-skills",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-project-skills",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Agent Skills for miku-project",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 概要

Release build が sources JAR を実行対象として選ぶ問題を修正し、`miku-project-skills` を 0.12.2 へ更新します。

## 変更内容

- 実行可能 JAR の検索時に `miku-project-sources-<version>.jar` を明示的に除外
- `package.json` と `package-lock.json` の root package version を 0.12.2 へ更新
- 開発手順に記載した SemVer と Git tag の例を 0.12.2 に更新

## 確認

- workflow と同じ検索式で `miku-project-0.12.0.jar` を選択し、`java -jar --version` が成功
- `npm run build`（15 files / 39 tests passed）