### PR TITLE
Release workflowを修正し0.12.3へ更新

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          package_version="$(node -p \"require('./package.json').version\")"
+          package_version="$(node -p "require('./package.json').version")"
           source_zip="bundle/miku-project-skills-${package_version}.zip"
           test -s "${source_zip}"
           target_zip="bundle/miku-project-skills-${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}.zip"

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,11 +69,11 @@ Git tag は別途作成するため、通常は `--no-git-tag-version` を付け
 例:
 
 ```bash
-npm version 0.12.2 --no-git-tag-version
+npm version 0.12.3 --no-git-tag-version
 ```
 
-`package.json` と `package-lock.json` では npm の SemVer として `0.12.2`
-のように記録します。Git tag やリリース名として `v0.12.2` を使う場合でも、
+`package.json` と `package-lock.json` では npm の SemVer として `0.12.3`
+のように記録します。Git tag やリリース名として `v0.12.3` を使う場合でも、
 package version には先頭の `v` を付けません。
 
 更新後は次で root package version が揃っていることを確認します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-project-skills",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-project-skills",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-project-skills",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "description": "Agent Skills for miku-project",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 概要

Release ZIP の版数取得で shell 構文エラーになる問題を修正し、`miku-project-skills` を 0.12.3 へ更新します。

## 変更内容

- Release workflow の `node -p` 呼び出しから不要なバックスラッシュを除去
- `package.json` と `package-lock.json` の root package version を 0.12.3 へ更新
- 開発手順に記載した SemVer と Git tag の例を 0.12.3 に更新

## 確認

- workflow と同じ `node -p` 式で version と ZIP の存在を確認
- `npm run build`（15 files / 39 tests passed）