### PR TITLE
miku-project Issue #123: GitHub rename follow-up

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -144,6 +144,19 @@
 
 - [x] `miku-project-skills` 側だけで無理に実装せず、upstream (`miku-project`) 側の API 追加や公開面整理が妥当な場合は、その都度 `miku-project` 側アクション候補として相談する
 
+### miku-project Issue #123: naming migration
+
+- [x] repository/package名を `miku-project-skills` に統一する
+- [x] installed skill名とdirectoryを `igapyon-miku-project` / `skills/igapyon-miku-project/` に統一する
+- [x] canonical triggerとlegacy compatibility triggerを一つのSkillで提供する
+- [x] runtime、bundle、Release workflow、テストをcanonical path/nameへ移行する
+- [x] GitHub Settingsでrepositoryを `igapyon/mikuproject-skills` から `igapyon/miku-project-skills` へrenameする（repository owner作業）
+- [x] rename後にlocal `origin`、fetch、package metadata、管理中URLを新repository名で確認する
+- [ ] 次のreview済みpublication workflowでcanonical `origin`へのpush routingを確認する
+- [ ] upstream MCP repository/package/tool/resource identifierの移行完了後、legacy MCP compatibility境界を再確認する
+
+詳細なbaseline、現状、handoff手順は `docs/naming-migration.md` を参照する。
+
 ### upstream `miku-project-java`: completed
 
 現時点で、Agent Skills から Java runtime を優先利用するための主要 CLI surface は揃った。

--- a/docs/miku-soft-reference.md
+++ b/docs/miku-soft-reference.md
@@ -5,20 +5,20 @@ topics: [miku-soft, agent-skills, miku-project]
 category: reference
 status: active
 audience: [maintainer, developer, agent]
-updated: 2026-08-06
+updated: 2026-08-12
 sources:
   - type: local-file
     role: primary
     path: skills/igapyon-miku-project/SKILL.md
-    checked: 2026-08-06
+    checked: 2026-08-12
   - type: canonical-repository
     role: supporting
     url: https://github.com/igapyon/miku-project
-    checked: 2026-08-06
+    checked: 2026-08-12
   - type: canonical-repository
     role: supporting
     url: https://github.com/igapyon/miku-project-java
-    checked: 2026-08-06
+    checked: 2026-08-12
 ---
 
 # miku-soft 標準参照
@@ -31,8 +31,9 @@ reference、backend policy、version 付き runtime artifact と配布 bundle �
 
 - miku-soft 共通標準: インストール済みの `igapyon-miku-soft-developer` skill と、その参照先を正本とする。
 - 製品正本: [miku-project](https://github.com/igapyon/miku-project) と [miku-project-java](https://github.com/igapyon/miku-project-java)。
-- 同梱 runtime artifact: `skills/igapyon-miku-project/runtime/` の `0.8.3.3` artifact。
-- 確認日: 2026-08-06。
+- 同梱 runtime artifact: `skills/igapyon-miku-project/runtime/` の Node.js
+  `0.12.0` と Java `0.12.0` artifact。
+- 確認日: 2026-08-12。
 - 標準 skill の固定 commit: この環境の skill root は Git worktree ではないため未取得。release 前に、利用した標準の version または commit を release record に固定する。
 
 共通標準本文をこのリポジトリへ複製しない。旧ファイル名への互換リンクは残すが、

--- a/docs/naming-migration.md
+++ b/docs/naming-migration.md
@@ -1,8 +1,11 @@
 # Miku Project Naming Migration
 
-This record implements the naming contract in GitHub Issue #63. It is kept in
-the repository so that the Release/PR handoff can repeat the fixed baseline and
-runtime provenance without relying on a moving GitHub URL.
+This record implements the repository-local naming contract in
+[GitHub Issue #63](https://github.com/igapyon/mikuproject-skills/issues/63)
+and tracks the Agent Skills portion of the product-family migration in
+[miku-project Issue #123](https://github.com/igapyon/miku-project/issues/123).
+It is kept in the repository so that the Release/PR handoff can repeat the
+fixed baseline and runtime provenance without relying on a moving GitHub URL.
 
 ## Baseline Recorded Before the Migration
 
@@ -14,10 +17,28 @@ runtime provenance without relying on a moving GitHub URL.
 | Latest Release | `v0.8.1.1` (2026-05-01) |
 | Baseline checks | `npm test` and `npm run build:bundle:zip` passed |
 
-The GitHub repository rename to `igapyon/miku-project-skills` must be performed
-by a repository owner in GitHub Settings. After that rename, update `origin` to
-the new SSH URL and verify a fetch and push against the new URL before
-publishing a Release.
+## Current Migration Status
+
+Checked on 2026-08-12:
+
+- repository-local Issue #63 is closed and the tracked Agent Skill source uses
+  the canonical package, installed skill, directory, runtime, and bundle names
+- `igapyon/miku-project` and `igapyon/miku-project-java` are the current
+  canonical upstream repositories
+- the GitHub repository is `igapyon/miku-project-skills`; the old
+  `igapyon/mikuproject-skills` API URL redirects to the canonical repository
+- local `origin` is `git@github.com:igapyon/miku-project-skills.git`, and
+  `git fetch origin --prune` succeeded after the rename
+- the MCP repository is still `igapyon/mikuproject-mcp`; the target
+  `igapyon/miku-project-mcp` repository does not exist yet
+
+The Agent Skills repository rename and local fetch verification are complete.
+No verification-only push was performed; verify push routing through the next
+reviewed publication workflow instead of creating an unrelated remote update.
+
+The remaining MCP repository rename is a human-owned operation. Do not change
+managed MCP URLs or identifiers to a target repository before that target and
+its compatibility contract exist.
 
 ## Canonical Identity
 
@@ -40,7 +61,7 @@ identity.
 | `mikuproject`, `miku project`, `mikuku project` | Activation triggers for the canonical skill; keep while existing prompts use them. |
 | `mikuproject_*` and `mikuproject://` | MCP backend tools and resource URIs; retain until the MCP backend migration supplies and tests canonical identifiers. |
 | `mikuproject_workbook_json` | Existing workbook interchange format; retain until its wire-format migration is separately versioned. |
-| `igapyon/mikuproject-mcp` and `@igapyon/mikuproject-mcp-node` | Current MCP backend repository and package; MCP server rename is outside this Issue. |
+| `igapyon/mikuproject-mcp` and `@igapyon/mikuproject-mcp-node` | Current MCP backend repository and package; their migration is tracked by umbrella Issue #123, but this adapter retains them until the upstream MCP repository supplies and tests canonical identifiers. |
 | Java runtime | Pinned to the published `v0.12.0` artifact, whose `ai spec` uses the canonical `miku-project` heading. |
 
 All other repository, package, directory, bundle, runtime, documentation, and

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "description": "Agent Skills for miku-project",
   "license": "Apache-2.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/igapyon/miku-project-skills.git"
+  },
+  "bugs": {
+    "url": "https://github.com/igapyon/miku-project-skills/issues"
+  },
+  "homepage": "https://github.com/igapyon/miku-project-skills#readme",
   "engines": {
     "node": ">=20"
   },

--- a/tests/miku-project-naming-contract.test.js
+++ b/tests/miku-project-naming-contract.test.js
@@ -6,11 +6,17 @@ import { describe, expect, it } from "vitest";
 const ROOT = process.cwd();
 const skillRoot = path.resolve(ROOT, "skills/igapyon-miku-project");
 const skillMarkdown = fs.readFileSync(path.resolve(skillRoot, "SKILL.md"), "utf8");
+const namingMigration = fs.readFileSync(path.resolve(ROOT, "docs/naming-migration.md"), "utf8");
+const mikuSoftReference = fs.readFileSync(path.resolve(ROOT, "docs/miku-soft-reference.md"), "utf8");
+const todo = fs.readFileSync(path.resolve(ROOT, "TODO.md"), "utf8");
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(ROOT, "package.json"), "utf8"));
 
 describe("miku-project naming contract", () => {
   it("ships one canonical installed skill identity", () => {
     expect(packageJson.name).toBe("miku-project-skills");
+    expect(packageJson.repository.url).toBe("git+https://github.com/igapyon/miku-project-skills.git");
+    expect(packageJson.bugs.url).toBe("https://github.com/igapyon/miku-project-skills/issues");
+    expect(packageJson.homepage).toBe("https://github.com/igapyon/miku-project-skills#readme");
     expect(fs.existsSync(skillRoot)).toBe(true);
     expect(fs.existsSync(path.resolve(ROOT, "skills/mikuproject"))).toBe(false);
     expect(skillMarkdown).toContain("name: igapyon-miku-project");
@@ -34,5 +40,21 @@ describe("miku-project naming contract", () => {
       "miku-project-sources-0.12.0.jar",
       "miku-project-sources-0.12.0.tgz"
     ]);
+  });
+
+  it("tracks the umbrella rename and its human-owned GitHub handoff", () => {
+    expect(namingMigration).toContain("miku-project Issue #123");
+    expect(namingMigration).toContain("repository-local Issue #63");
+    expect(namingMigration).toContain("the GitHub repository is `igapyon/miku-project-skills`");
+    expect(namingMigration).toContain("`igapyon/mikuproject-skills` API URL redirects");
+    expect(namingMigration).toContain("git@github.com:igapyon/miku-project-skills.git");
+    expect(namingMigration).toContain("`git fetch origin --prune` succeeded");
+    expect(todo).toContain("miku-project Issue #123: naming migration");
+    expect(todo).toContain("rename後にlocal `origin`、fetch、package metadata、管理中URLを新repository名で確認する");
+  });
+
+  it("records the runtime versions actually bundled by the canonical skill", () => {
+    expect(mikuSoftReference).toContain("Node.js\n  `0.12.0` と Java `0.12.0` artifact");
+    expect(mikuSoftReference).not.toContain("`0.8.3.3` artifact");
   });
 });


### PR DESCRIPTION
## Overview

Track the completed Agent Skills repository rename as part of the miku-project family naming migration.

## Changes

- Record `igapyon/miku-project-skills` as the canonical repository and preserve the old API URL redirect as migration evidence.
- Add canonical repository, Issues, and homepage metadata to the package.
- Update the naming migration TODO and runtime reference, and protect the documented migration state with naming-contract tests.
- Keep the existing MCP identifiers as a documented compatibility boundary until its upstream migration is complete.